### PR TITLE
Issue #1: Make street address optional

### DIFF
--- a/app/components/display-congress.js
+++ b/app/components/display-congress.js
@@ -6,14 +6,17 @@ export default Ember.Component.extend({
 
   congress: null,
 
+  // We can assume only one district per congress response from the server
+  district: Ember.computed.alias('congress.district.districts.firstObject'),
+
   successfulLoad: Ember.computed.and(
-    'congress.district.id',
+    'district.id',
     'congress.representatives.length',
     'congress.senators.length'
   ),
 
-  permalink: Ember.computed('congress.district.id', function() {
-    return `http://www.callmycongress.com/${this.get('congress.district.id')}`;
+  permalink: Ember.computed('district.id', function() {
+    return `http://www.callmycongress.com/${this.get('district.id')}`;
   }),
 
   actions: {

--- a/app/components/lookup-congress.js
+++ b/app/components/lookup-congress.js
@@ -11,9 +11,9 @@ export default Ember.Component.extend({
     const street = encodeURI(this.get('street'));
     const zip = this.get('zip');
     return $.getJSON(`/api/district-from-address?street=${street}&zip=${zip}`)
-      .then(district => {
-        if (district.id) {
-          this.get('router').transitionTo('district', district.id);
+      .then(result => {
+        if (result.districts && result.districts[0] && result.districts[0].id) {
+          this.get('router').transitionTo('district', result.districts[0].id);
         } else {
           this.get('message').display('errors.general');
         }

--- a/app/components/lookup-congress.js
+++ b/app/components/lookup-congress.js
@@ -8,9 +8,19 @@ export default Ember.Component.extend({
   zip: null,
 
   lookupDistrict() {
-    const street = encodeURI(this.get('street'));
+    const street = this.get('street');
     const zip = this.get('zip');
-    return $.getJSON(`/api/district-from-address?street=${street}&zip=${zip}`)
+
+    let url;
+
+    if (street) {
+      const encodedStreet = encodeURI(street);
+      url = `/api/district-from-address?street=${encodedStreet}&zip=${zip}`;
+    } else {
+      url = `/api/district-from-address?zip=${zip}`;
+    }
+
+    return $.getJSON(url)
       .then(result => {
         if (result.districts && result.districts[0] && result.districts[0].id) {
           this.get('router').transitionTo('district', result.districts[0].id);
@@ -27,8 +37,8 @@ export default Ember.Component.extend({
     event.preventDefault();
     this.get('message').clear();
 
-    if (this.get('street') === null || this.get('zip') === null) {
-      this.get('message').display('errors.server.INCOMPLETE_ADDRESS');
+    if (this.get('zip') === null) {
+      this.get('message').display('errors.server.MISSING_ZIP');
       return;
     }
 

--- a/app/components/lookup-congress.js
+++ b/app/components/lookup-congress.js
@@ -7,6 +7,8 @@ export default Ember.Component.extend({
   street: null,
   zip: null,
 
+  districtsToPickFrom: null,
+
   lookupDistrict() {
     const street = this.get('street');
     const zip = this.get('zip');
@@ -22,11 +24,17 @@ export default Ember.Component.extend({
 
     return $.getJSON(url)
       .then(result => {
-        if (result.districts && result.districts[0] && result.districts[0].id) {
-          this.get('router').transitionTo('district', result.districts[0].id);
-        } else {
-          this.get('message').display('errors.general');
+        if (result.districts) {
+          if (result.districts.length === 1) {
+            this.get('router').transitionTo('district', result.districts[0].id);
+            return;
+          } else if (result.districts.length > 1) {
+            this.set('districtsToPickFrom', result.districts);
+            return;
+          }
         }
+
+        this.get('message').display('errors.general');
       })
       .catch(error => {
         this.get('message').displayFromServer(error);

--- a/app/components/pick-district.js
+++ b/app/components/pick-district.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['pick-district'],
+
+  districts: null
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -35,7 +35,7 @@ export default {
   },
 
   about: {
-    attribution: "This app runs off data made freely available by the {{link-census}}US Census Geocoding Services{{/link-census}} and {{link-govtrack}}GovTrack.us{{/link-govtrack}}. It was created by {{link-marie}}Marie Chatfield{{/link-marie}}. View the source code or contribute changes on {{link-github}}GitHub{{/link-github}}."
+    attribution: "This app runs off data made freely available by the {{link-census}}US Census Geocoding Services{{/link-census}}, {{link-govtrack}}GovTrack.us{{/link-govtrack}}, and {{link-whoismyrep}}whoismyrepresentative.com{{/link-whoismyrep}}. It was created by {{link-marie}}Marie Chatfield{{/link-marie}}. View the source code or contribute changes on {{link-github}}GitHub{{/link-github}}."
   },
 
   errors: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -12,6 +12,10 @@ export default {
     search: 'Find My Congress'
   },
 
+  pickDistrict: {
+    helpText: 'Your zip code falls within multiple congressional districts. Pick a district below to see its representatives, or provide a street address and search again for more accurate results.'
+  },
+
   displayCongress: {
     back: 'Search Again',
     permalink: 'Permanent Link to This Page'

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -37,11 +37,11 @@ export default {
   errors: {
     general: 'Something went wrong.',
     server: {
-      INCOMPLETE_ADDRESS: 'Please fill out both street address and zip code.',
       INVALID_ADDRESS: 'Could not find valid address. Please double check the street address and zip code.',
       INVALID_DISTRICT: 'District number provided does not exist in your state.',
       INVALID_DISTRICT_ID: 'Provided URL does not map to a valid state and district number.',
       INVALID_STATE: 'State abbreviation provided does not match any known states.',
+      MISSING_ZIP: 'Please provide a valid zip code.',
       MISSING_DISTRICT_ID: 'Please provide a valid district id to look up representatives.',
       UNKNOWN: 'Something went wrong.'
     }

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -18,7 +18,7 @@ export default {
   },
 
   geography: {
-    address: 'Street Address',
+    address: 'Street Address (optional)',
     district: 'Congressional District',
     state: 'State',
     zipCode: 'Zip Code'

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -13,6 +13,7 @@
 {{translate-format-link key="about.attribution"
                         links=(hash census="https://geocoding.geo.census.gov/"
                                     govtrack="https://www.govtrack.us/developers"
+                                    whoismyrep="http://www.whoismyrepresentative.com/api"
                                     marie="http://mariechatfield.com/"
                                     github="https://github.com/mchat/call-my-congress")}}
 </div>

--- a/app/templates/components/display-congress.hbs
+++ b/app/templates/components/display-congress.hbs
@@ -1,12 +1,12 @@
 {{#if successfulLoad}}
   <div class="row display-congress__state">
     <div class="one-half column"><strong>{{t "geography.state"}}</strong></div>
-    <div class="one-half column">{{congress.district.state}}</div>
+    <div class="one-half column">{{district.state}}</div>
   </div>
 
   <div class="row display-congress__district">
     <div class="one-half column"><strong>{{t "geography.district"}}</strong></div>
-    <div class="one-half column">{{congress.district.number}}</div>
+    <div class="one-half column">{{district.number}}</div>
   </div>
 
   <div class="row display-congress__permalink">

--- a/app/templates/components/lookup-congress.hbs
+++ b/app/templates/components/lookup-congress.hbs
@@ -24,3 +24,7 @@
             type="submit"}}
   </div>
 </form>
+
+{{#if districtsToPickFrom}}
+  {{pick-district districts=districtsToPickFrom}}
+{{/if}}

--- a/app/templates/components/pick-district.hbs
+++ b/app/templates/components/pick-district.hbs
@@ -1,0 +1,9 @@
+{{t "pickDistrict.helpText"}}
+
+<ul class="row--extra-space">
+{{#each districts as |district|}}
+  <li class="pick-district__link">
+    {{link-to district.id 'district' district.id}}
+  </li>
+{{/each}}
+</ul>

--- a/backend/tests/fixtures/api.js
+++ b/backend/tests/fixtures/api.js
@@ -73,6 +73,79 @@ const DISTRICT_OBJECT = {
   }
 };
 
+const ZIP_ONLY_DISTRICT_OBJECT = {
+  results: [
+    {
+      district: '12',
+      link: 'http://pelosi.house.gov',
+      name: 'Nancy Pelosi',
+      office: '233 Cannon House Office Building',
+      party: 'D',
+      phone: '202-225-4965',
+      state: 'CA'
+    },
+    {
+      district: 'Junior Seat',
+      link: 'http://www.boxer.senate.gov',
+      name: 'Barbara Boxer',
+      office: '112 Hart Senate Office Building',
+      party: 'D',
+      phone: '202-224-3553',
+      state: 'CA'
+    },
+    {
+      district: 'Senior Seat',
+      link: 'http://www.feinstein.senate.gov',
+      name: 'Dianne Feinstein',
+      office: '331 Hart Senate Office Building',
+      party: 'D',
+      phone: '202-224-3841',
+      state: 'CA'
+    }
+  ]
+};
+
+const ZIP_ONLY_WITH_TWO_DISTRICTS_OBJECT = {
+  results: [
+    {
+      district: '7',
+      link: 'http://culberson.house.gov',
+      name: 'John Culberson',
+      office: '2372 Rayburn House Office Building',
+      party: 'R',
+      phone: '202-225-2571',
+      state: 'TX'
+    },
+    {
+      district: '9',
+      link: 'http://algreen.house.gov',
+      name: 'Al Green',
+      office: '2347 Rayburn House Office Building',
+      party: 'D',
+      phone: '202-225-7508',
+      state: 'TX'
+    },
+    {
+      district: 'Senior Seat',
+      link: 'http://www.cornyn.senate.gov',
+      name: 'John Cornyn',
+      office: '517 Hart Senate Office Building',
+      party: 'R',
+      phone: '202-224-2934',
+      state: 'TX'
+    },
+    {
+      district: 'Junior Seat',
+      link: 'http://www.cruz.senate.gov',
+      name: 'Ted Cruz',
+      office: '404 Russell Senate Office Building',
+      party: 'R',
+      phone: '202-224-5922',
+      state: 'TX'
+    }
+  ]
+};
+
 const SENATORS_OBJECT = {
  meta: {
   limit: 100,
@@ -251,13 +324,34 @@ const REPRESENTATIVE_OBJECT = {
 };
 
 const DISTRICT = JSON.stringify(DISTRICT_OBJECT);
+const ZIP_ONLY_DISTRICT = JSON.stringify(ZIP_ONLY_DISTRICT_OBJECT);
+const ZIP_ONLY_WITH_TWO_DISTRICTS = JSON.stringify(ZIP_ONLY_WITH_TWO_DISTRICTS_OBJECT);
 const SENATORS = JSON.stringify(SENATORS_OBJECT);
 const REPRESENTATIVE = JSON.stringify(REPRESENTATIVE_OBJECT);
 
 const DISTRICT_RESPONSE = {
-  state: 'CA',
-  number: '12',
-  id: 'CA-12'
+  districts: [
+    {
+      state: 'CA',
+      number: '12',
+      id: 'CA-12'
+    }
+  ]
+};
+
+const TWO_DISTRICTS_RESPONSE = {
+  districts: [
+    {
+      state: 'TX',
+      number: '7',
+      id: 'TX-7'
+    },
+    {
+      state: 'TX',
+      number: '9',
+      id: 'TX-9'
+    }
+  ]
 };
 
 const CONGRESS_RESPONSE = {
@@ -268,8 +362,11 @@ const CONGRESS_RESPONSE = {
 
 module.exports = {
   DISTRICT,
+  ZIP_ONLY_DISTRICT,
+  ZIP_ONLY_WITH_TWO_DISTRICTS,
   SENATORS,
   REPRESENTATIVE,
   DISTRICT_RESPONSE,
+  TWO_DISTRICTS_RESPONSE,
   CONGRESS_RESPONSE
 };

--- a/tests/fixtures/congress.js
+++ b/tests/fixtures/congress.js
@@ -1,8 +1,12 @@
 export const COMPLETE_CONGRESS = {
   district: {
-    id: "CA-12",
-    number: "12",
-    state: "CA"
+    districts: [
+      {
+        id: "CA-12",
+        number: "12",
+        state: "CA"
+      }
+    ]
   },
   representatives: [
     {
@@ -333,9 +337,13 @@ export const NO_DISTRICT = {
 
 export const NO_REPRESENTATIVES =  {
   district: {
-    id: "CA-12",
-    number: "12",
-    state: "CA"
+    districts: [
+      {
+        id: "CA-12",
+        number: "12",
+        state: "CA"
+      }
+    ]
   },
   senators: [
     {
@@ -450,9 +458,13 @@ export const NO_REPRESENTATIVES =  {
 
 export const NO_SENATORS = {
   district: {
-    id: "CA-12",
-    number: "12",
-    state: "CA"
+    districts: [
+      {
+        id: "CA-12",
+        number: "12",
+        state: "CA"
+      }
+    ]
   },
   representatives: [
     {

--- a/tests/fixtures/districts.js
+++ b/tests/fixtures/districts.js
@@ -1,0 +1,24 @@
+export const SINGLE_DISTRICT = {
+  districts: [
+    {
+      id: 'CA-12',
+      state: 'CA',
+      number: '12'
+    }
+  ]
+};
+
+export const MULTIPLE_DISTRICTS = {
+  districts: [
+    {
+      id: 'TX-7',
+      state: 'TX',
+      number: '7'
+    },
+    {
+      id: 'TX-9',
+      state: 'TX',
+      number: '9'
+    }
+  ]
+};

--- a/tests/integration/components/lookup-congress-test.js
+++ b/tests/integration/components/lookup-congress-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { MULTIPLE_DISTRICTS } from '../../fixtures/districts';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('lookup-congress', 'Integration | Component | lookup congress', {
@@ -6,10 +7,18 @@ moduleForComponent('lookup-congress', 'Integration | Component | lookup congress
 });
 
 test('it renders', function(assert) {
-
   this.render(hbs`{{lookup-congress}}`);
 
   assert.ok(this.$('.lookup-congress__street').is(':visible'), 'renders street address input');
   assert.ok(this.$('.lookup-congress__zip').is(':visible'), 'renders zip code input');
   assert.ok(this.$('.lookup-congress__search').is(':visible'), 'renders search button');
+
+  assert.equal(this.$('.pick-district').length, 0, 'does not render pick-district');
+});
+
+test('renders pick-district component when multiple districts', function(assert) {
+  this.set('districts', MULTIPLE_DISTRICTS.districts);
+  this.render(hbs`{{lookup-congress districtsToPickFrom=districts}}`);
+
+  assert.equal(this.$('.pick-district').length, 1, 'renders pick-district');
 });

--- a/tests/integration/components/pick-district-test.js
+++ b/tests/integration/components/pick-district-test.js
@@ -1,0 +1,23 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import { SINGLE_DISTRICT, MULTIPLE_DISTRICTS } from '../../fixtures/districts';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('pick-district', 'Integration | Component | pick district', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.set('districts', SINGLE_DISTRICT.districts);
+  this.render(hbs`{{pick-district districts=districts}}`);
+
+  assert.equal(this.$('.pick-district__link').length, 1, 'shows a link for every district');
+
+  this.set('districts', MULTIPLE_DISTRICTS.districts);
+
+  const $districtLinks = this.$('.pick-district__link');
+  const $firstLink = $($districtLinks[0]);
+  const $secondLink = $($districtLinks[1]);
+  assert.equal($districtLinks.length, 2, 'shows a link for every district');
+  assert.equal($firstLink.text().trim(), 'TX-7', 'displays name of first district');
+  assert.equal($secondLink.text().trim(), 'TX-9', 'displays name of second district');
+});

--- a/tests/unit/components/lookup-congress-test.js
+++ b/tests/unit/components/lookup-congress-test.js
@@ -1,5 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
-import { SINGLE_DISTRICT } from '../../fixtures/districts';
+import { SINGLE_DISTRICT, MULTIPLE_DISTRICTS } from '../../fixtures/districts';
 import Ember from 'ember';
 import $ from 'jquery';
 import setupStubs from '../../helpers/setup-stubs';
@@ -114,6 +114,23 @@ test('lookupDistrict > transitions when response is successful with only zip', f
   this.component.lookupDistrict().then(() => {
     assert.equal(this.stubs.calls.router.transitionTo.length, 1, 'calls router.transitionTo');
     assert.deepEqual(this.stubs.calls.router.transitionTo[0], ['district', 'CA-12'], 'transitions to route based on id of response');
+    done();
+  });
+});
+
+test('lookupDistrict > sets districtsToPickFrom when multiple districts per zip', function(assert) {
+  this.responseSuccessful = true;
+  this.response = MULTIPLE_DISTRICTS;
+
+  this.component.setProperties({
+    zip: ZIP
+  });
+
+  const done = assert.async();
+
+  this.component.lookupDistrict().then(() => {
+    assert.deepEqual(this.component.get('districtsToPickFrom'), MULTIPLE_DISTRICTS.districts);
+    assert.equal(this.stubs.calls.router.transitionTo.length, 0, 'does not call calls router.transitionTo');
     done();
   });
 });

--- a/tests/unit/components/lookup-congress-test.js
+++ b/tests/unit/components/lookup-congress-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { SINGLE_DISTRICT } from '../../fixtures/districts';
 import Ember from 'ember';
 import $ from 'jquery';
 import setupStubs from '../../helpers/setup-stubs';
@@ -94,7 +95,7 @@ test('submit > does not make request unless both street and zip are provided', f
 
 test('lookupDistrict > transitions when response is successful', function(assert) {
   this.responseSuccessful = true;
-  this.response = { id: 'some-id' };
+  this.response = SINGLE_DISTRICT;
 
   this.component.setProperties({
     street: STREET,
@@ -105,7 +106,7 @@ test('lookupDistrict > transitions when response is successful', function(assert
 
   this.component.lookupDistrict().then(() => {
     assert.equal(this.stubs.calls.router.transitionTo.length, 1, 'calls router.transitionTo');
-    assert.deepEqual(this.stubs.calls.router.transitionTo[0], ['district', 'some-id'], 'transitions to route based on id of response');
+    assert.deepEqual(this.stubs.calls.router.transitionTo[0], ['district', 'CA-12'], 'transitions to route based on id of response');
     done();
   });
 });

--- a/tests/unit/components/lookup-congress-test.js
+++ b/tests/unit/components/lookup-congress-test.js
@@ -68,7 +68,7 @@ test('submit > makes request when street and zip are provided', function(assert)
   );
 });
 
-test('submit > does not make request unless both street and zip are provided', function(assert) {
+test('submit > does not make request unless zip is provided', function(assert) {
   this.component.submit(this.stubs.objects.event);
 
   assert.equal(this.stubs.calls.message.clear.length, 1, 'clears any existing messages');
@@ -81,16 +81,6 @@ test('submit > does not make request unless both street and zip are provided', f
   assert.equal(this.stubs.calls.message.clear.length, 2, 'clears any existing messages');
   assert.equal(this.stubs.calls.message.display.length, 2, 'displays an error message');
   assert.equal(this.stubs.calls.router.transitionTo.length, 0, 'does not attempt to transition');
-
-  this.component.setProperties({
-    street: null,
-    zip: ZIP
-  });
-  this.component.submit(this.stubs.objects.event);
-
-  assert.equal(this.stubs.calls.message.clear.length, 3, 'clears any existing messages');
-  assert.equal(this.stubs.calls.message.display.length, 3, 'displays an error message');
-  assert.equal(this.stubs.calls.router.transitionTo.length, 0, 'does not attempt to transition');
 });
 
 test('lookupDistrict > transitions when response is successful', function(assert) {
@@ -99,6 +89,23 @@ test('lookupDistrict > transitions when response is successful', function(assert
 
   this.component.setProperties({
     street: STREET,
+    zip: ZIP
+  });
+
+  const done = assert.async();
+
+  this.component.lookupDistrict().then(() => {
+    assert.equal(this.stubs.calls.router.transitionTo.length, 1, 'calls router.transitionTo');
+    assert.deepEqual(this.stubs.calls.router.transitionTo[0], ['district', 'CA-12'], 'transitions to route based on id of response');
+    done();
+  });
+});
+
+test('lookupDistrict > transitions when response is successful with only zip', function(assert) {
+  this.responseSuccessful = true;
+  this.response = SINGLE_DISTRICT;
+
+  this.component.setProperties({
     zip: ZIP
   });
 


### PR DESCRIPTION
Per #1, allow users to search for their representatives by zip code alone (without having to provide a street address). Uses [whoismyrepresentative.com's API](http://www.whoismyrepresentative.com/api) to search by zip code if no street address is provided. If street address is provided, uses US Census API for more accurate district lookup.

If multiple congressional districts are found for a given zip code, displays list of districts. Users can either click through to a district, or add a street address and search again to be routed to their exact district.

<img width="1437" alt="zip_with_multiple_districts" src="https://cloud.githubusercontent.com/assets/4974085/20646760/ae8525ec-b436-11e6-9cea-a1cce3f35b76.png">



