### PR TITLE
Force nginx to route to https, update permalink urls.

### DIFF
--- a/app/components/display-congress.js
+++ b/app/components/display-congress.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
   ),
 
   permalink: Ember.computed('district.id', function() {
-    return `http://www.callmycongress.com/${this.get('district.id')}`;
+    return `https://www.callmycongress.com/${this.get('district.id')}`;
   }),
 
   actions: {

--- a/static.json
+++ b/static.json
@@ -1,5 +1,6 @@
 {
   "root": "dist/",
+  "https_only": true,
   "proxies": {
     "/api/": {
       "origin": "https://call-my-congress-backend.herokuapp.com/api"


### PR DESCRIPTION
Now that SSL is set up for callmycongress.com, route all requests to https and update links in the app to use https.