### PR TITLE
Resolves #8. Fix typo in expected message for invalid zip API call.

### DIFF
--- a/backend/app/server.js
+++ b/backend/app/server.js
@@ -12,7 +12,7 @@ const ROLE_BASE_URL = 'https://www.govtrack.us/api/v2/role';
 
 // When zip code is not found, the response succeeds with code 200 but the body
 // has this message instead of a JSON object.
-const ZIP_ONLY_ERROR_BODY = `<result message='No Data Found'/>`;
+const ZIP_ONLY_ERROR_BODY = `<result message='No Data Found' />`;
 
 const DEFAULT_PORT = 3000;
 

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -84,7 +84,7 @@ describe('server', function() {
         });
 
         it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
-          stubRequest(validApiURL, `<result message='No Data Found'/>`);
+          stubRequest(validApiURL, `<result message='No Data Found' />`);
 
           supertest(this.server)
             .get('/api/district-from-address?zip=20500')


### PR DESCRIPTION
www.whoismyrepresentative.com/getall_mems.php?zip=12345&output=json

Response for invalid zip codes from whoismyrepresentative.com has status 200 and response body `<result message='No Data Found' />`. I originally mistyped the expected response body, so the server was returning a generic error message for invalid zip codes instead of the expected `INVALID_ADDRESS` error message.