### PR TITLE
Resolves #9. Click header to return to home page.

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,5 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  message: Ember.inject.service()
+  message: Ember.inject.service(),
+
+  actions: {
+    linkToIndex() {
+      this.transitionToRoute('index');
+    }
+  }
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-<div class="header">
+<div class="header" {{action "linkToIndex"}}>
   <h1 class="header__title">Call My Congress</h1>
 </div>
 

--- a/public/assets/call-my-congress.css
+++ b/public/assets/call-my-congress.css
@@ -41,6 +41,7 @@ body {
   color: var(--color-white);
   background-color: var(--color-red);
   font-family: "Merriweather", serif;
+  cursor: pointer;
 }
 
 .footer {

--- a/tests/acceptance/return-to-index-test.js
+++ b/tests/acceptance/return-to-index-test.js
@@ -1,0 +1,46 @@
+import { test } from 'qunit';
+import $ from 'jquery';
+import moduleForAcceptance from 'call-my-congress/tests/helpers/module-for-acceptance';
+import setupStubs from '../helpers/setup-stubs';
+
+moduleForAcceptance('Acceptance | return to index', {
+  beforeEach() {
+    this.stubs = setupStubs([
+      {
+        name: '$',
+        methodOverrides: [{
+          name: 'getJSON',
+          override: () => {
+            return {
+              catch() { return {}; }
+            };
+          }
+        }]
+      }
+    ]);
+
+    $.getJSON = this.stubs.objects.$.getJSON;
+  },
+
+  afterEach() {
+    $.getJSON = this.orginalGetJSON;
+  }
+});
+
+test('visiting index', function(assert) {
+  visit('/');
+  click('.header');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/', 'clicking header on index does not change URL');
+  });
+});
+
+test('visiting district', function(assert) {
+  visit('/CA-12');
+  click('.header');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/', 'clicking header on district page transitions to index');
+  });
+});


### PR DESCRIPTION
Click anywhere on the header to return to home page. Should be especially useful on mobile devices, where the "Search Again" button is pushed far down and off the page.