### PR TITLE
Resolves #16. Correctly handles states with at large districts.

### DIFF
--- a/backend/app/server.js
+++ b/backend/app/server.js
@@ -14,6 +14,9 @@ const ROLE_BASE_URL = 'https://www.govtrack.us/api/v2/role';
 // has this message instead of a JSON object.
 const ZIP_ONLY_ERROR_BODY = `<result message='No Data Found' />`;
 
+const AT_LARGE_DISTRICT_NAME = 'Congressional District (at Large)';
+const AT_LARGE_DISTRICT_NUMBER = 0;
+
 const DEFAULT_PORT = 3000;
 
 // Geography layer that includes information on the 115th Congressional Districts
@@ -72,6 +75,10 @@ function getDistrictsZipOnly(geography) {
       // Filter out all non-numeric districts (i.e. "Junior Seat" for senators)
       .filter(district => !isNaN(district));
 
+    if (state && districtNumbers.length === 0) {
+      districtNumbers.push(AT_LARGE_DISTRICT_NUMBER);
+    }
+
     const districts = districtNumbers.map(number => {
       return {
         state,
@@ -100,8 +107,12 @@ function getDistricts(geography) {
     }
 
     const address = result.result.addressMatches[0];
-    const number = address.geographies['115th Congressional Districts'][0].BASENAME;
+    let number = address.geographies['115th Congressional Districts'][0].BASENAME;
     const state = address.addressComponents.state;
+
+    if (state && number === AT_LARGE_DISTRICT_NAME) {
+      number = AT_LARGE_DISTRICT_NUMBER;
+    }
 
     const id = `${state}-${number}`;
 

--- a/backend/tests/fixtures/api.js
+++ b/backend/tests/fixtures/api.js
@@ -2,74 +2,145 @@ const DISTRICT_OBJECT = {
   result: {
     addressMatches: [
       {
-        addressComponents: {
-          city: 'SAN FRANCISCO',
-          fromAddress: '158',
-          preDirection: '',
-          preQualifier: '',
-          preType: '',
-          state: 'CA',
-          streetName: 'DUBOCE',
-          suffixDirection: '',
-          suffixQualifier: '',
-          suffixType: 'AVE',
-          toAddress: '198',
-          zip: '94103'
-        },
-        coordinates: {
-          x: -122.42422,
-          y: 37.769764
-        },
         geographies: {
           '115th Congressional Districts': [
             {
-              AREALAND: 101086658,
-              AREAWATER: 211581419,
-              BASENAME: '12',
-              CD115: '12',
-              CDSESSN: '115',
-              CENTLAT: '+37.7853375',
-              CENTLON: '-122.4347034',
-              FUNCSTAT: 'N',
-              GEOID: '0612',
-              INTPTLAT: '+37.7855141',
-              INTPTLON: '-122.4340005',
-              LSADC: 'C2',
-              MTFCC: 'G5200',
-              NAME: 'Congressional District 12',
-              OBJECTID: 309,
               OID: 211904492478597,
               STATE: '06',
-              'STGEOMETRY.AREA': 5.0144496E+8,
-              'STGEOMETRY.LEN': 132664.16
+              FUNCSTAT: 'N',
+              NAME: 'Congressional District 12',
+              AREAWATER: 211581427,
+              CDSESSN: '115',
+              LSADC: 'C2',
+              CENTLON: '-122.4347034',
+              BASENAME: '12',
+              INTPTLAT: '+37.7855141',
+              MTFCC: 'G5200',
+              GEOID: '0612',
+              CENTLAT: '+37.7853375',
+              CD115: '12',
+              INTPTLON: '-122.4340005',
+              AREALAND: 101086653,
+              OBJECTID: 118
             }
           ]
         },
-        matchedAddress: '180 DUBOCE AVE, SAN FRANCISCO, CA, 94103',
+        matchedAddress: '1 DR CARLTON P GOODLETT PL, SAN FRANCISCO, CA, 94102',
+        coordinates: {
+          x: -122.41827,
+          y: 37.77863
+        },
         tigerLine: {
-          side: 'R',
-          tigerLineId: '192284146'
+          tigerLineId: '635441232',
+          side: 'L'
+        },
+        addressComponents: {
+          fromAddress: '1',
+          toAddress: '99',
+          preQualifier: '',
+          preDirection: '',
+          preType: '',
+          streetName: 'DR CARLTON P GOODLETT',
+          suffixType: 'PL',
+          suffixDirection: '',
+          suffixQualifier: '',
+          zip: '94102',
+          city: 'SAN FRANCISCO',
+          state: 'CA'
         }
       }
     ],
     input: {
       address: {
-        street: '180 Duboce Ave',
-        zip: '94103'
+        street: '1 Dr Carlton B Goodlett Pl',
+        zip: '94102'
       },
       benchmark: {
+        isDefault: false,
         benchmarkDescription: 'Public Address Ranges - Current Benchmark',
         benchmarkName: 'Public_AR_Current',
+        id: '4'
+      },
+      vintage: {
+        vintageName: 'Current_Current',
+        isDefault: true,
+        vintageDescription: 'Current Vintage - Current Benchmark',
+        id: '4'
+      }
+    }
+  }
+};
+
+const AT_LARGE_DISTRICT_OBJECT = {
+  result: {
+    input: {
+      address: {
+        street: '2 Carson St',
+        zip: '59601'
+      },
+      benchmark: {
         id: '4',
-        isDefault: false
+        isDefault: false,
+        benchmarkName: 'Public_AR_Current',
+        benchmarkDescription: 'Public Address Ranges - Current Benchmark'
       },
       vintage: {
         id: '4',
         isDefault: true,
-        vintageDescription: 'Current Vintage - Current Benchmark',
-        vintageName: 'Current_Current'
+        vintageName: 'Current_Current',
+        vintageDescription: 'Current Vintage - Current Benchmark'
       }
-    }
+    },
+    addressMatches: [
+      {
+        geographies: {
+          '115th Congressional Districts': [
+            {
+              OID: 211904692358327,
+              STATE: '30',
+              FUNCSTAT: 'N',
+              NAME: 'Congressional District (at Large)',
+              AREAWATER: 3867533734,
+              CDSESSN: '115',
+              LSADC: 'C1',
+              CENTLON: '-109.6329861',
+              BASENAME: 'Congressional District (at Large)',
+              INTPTLAT: '+47.0511771',
+              MTFCC: 'G5200',
+              GEOID: '3000',
+              CENTLAT: '+47.0526268',
+              CD115: '00',
+              INTPTLON: '-109.6348174',
+              AREALAND: 376964409491,
+              OBJECTID: 417
+            }
+          ]
+        },
+        matchedAddress: '2 N CARSON ST, HELENA, MT, 59601',
+        coordinates: {
+          x: -112.012146,
+          y: 46.584167
+        },
+        tigerLine: {
+          side: 'L',
+          tigerLineId: '202349954'
+        },
+        addressComponents: {
+          fromAddress: '2',
+          toAddress: '98',
+          preQualifier: '',
+          preDirection: 'N',
+          preType: '',
+          streetName: 'CARSON',
+          suffixType: 'ST',
+          suffixDirection: '',
+          suffixQualifier: '',
+          state: 'MT',
+          zip: '59601',
+          city: 'HELENA'
+        }
+      }
+    ]
   }
 };
 
@@ -142,6 +213,29 @@ const ZIP_ONLY_WITH_TWO_DISTRICTS_OBJECT = {
       party: 'R',
       phone: '202-224-5922',
       state: 'TX'
+    }
+  ]
+};
+
+const ZIP_ONLY_WITH_AT_LARGE_DISTRICT_OBJECT = {
+  results: [
+    {
+      name: 'Steve Daines',
+      party: 'R',
+      state: 'MT',
+      district: 'Junior Seat',
+      phone: '202-224-2651',
+      office: '320 Hart Senate Office Building',
+      link: 'http://www.daines.senate.gov'
+    },
+    {
+      name: 'Jon Tester',
+      party: 'D',
+      state: 'MT',
+      district: 'Senior Seat',
+      phone: '202-224-2644',
+      office: '311 Hart Senate Office Building',
+      link: 'http://www.tester.senate.gov'
     }
   ]
 };
@@ -324,8 +418,10 @@ const REPRESENTATIVE_OBJECT = {
 };
 
 const DISTRICT = JSON.stringify(DISTRICT_OBJECT);
+const AT_LARGE_DISTRICT = JSON.stringify(AT_LARGE_DISTRICT_OBJECT);
 const ZIP_ONLY_DISTRICT = JSON.stringify(ZIP_ONLY_DISTRICT_OBJECT);
 const ZIP_ONLY_WITH_TWO_DISTRICTS = JSON.stringify(ZIP_ONLY_WITH_TWO_DISTRICTS_OBJECT);
+const ZIP_ONLY_WITH_AT_LARGE_DISTRICT = JSON.stringify(ZIP_ONLY_WITH_AT_LARGE_DISTRICT_OBJECT);
 const SENATORS = JSON.stringify(SENATORS_OBJECT);
 const REPRESENTATIVE = JSON.stringify(REPRESENTATIVE_OBJECT);
 
@@ -354,6 +450,16 @@ const TWO_DISTRICTS_RESPONSE = {
   ]
 };
 
+const AT_LARGE_DISTRICT_RESPONSE = {
+  districts: [
+    {
+      state: 'MT',
+      number: '0',
+      id: 'MT-0'
+    }
+  ]
+};
+
 const CONGRESS_RESPONSE = {
   district: DISTRICT_RESPONSE,
   representatives: REPRESENTATIVE_OBJECT.objects,
@@ -362,11 +468,14 @@ const CONGRESS_RESPONSE = {
 
 module.exports = {
   DISTRICT,
+  AT_LARGE_DISTRICT,
   ZIP_ONLY_DISTRICT,
   ZIP_ONLY_WITH_TWO_DISTRICTS,
+  ZIP_ONLY_WITH_AT_LARGE_DISTRICT,
   SENATORS,
   REPRESENTATIVE,
   DISTRICT_RESPONSE,
   TWO_DISTRICTS_RESPONSE,
+  AT_LARGE_DISTRICT_RESPONSE,
   CONGRESS_RESPONSE
 };

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -48,6 +48,14 @@ describe('server', function() {
           .expect(200, fixtures.DISTRICT_RESPONSE, done);
       });
 
+      it('returns correctly formatted response for address that in state with a single at-large district', function testSlash(done) {
+        stubRequest(validApiURL, fixtures.AT_LARGE_DISTRICT);
+
+        supertest(this.server)
+          .get('/api/district-from-address?street=1600%20Pennsylvania%20Ave&zip=20500')
+          .expect(200, fixtures.AT_LARGE_DISTRICT_RESPONSE, done);
+      });
+
       it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
         stubRequest(validApiURL, { message: 'failed with some error' }, true);
 
@@ -75,12 +83,28 @@ describe('server', function() {
             .expect(200, fixtures.DISTRICT_RESPONSE, done);
         });
 
-        it('with successful API calls, returns correctly formatted response', function testSlash(done) {
+        it('returns correctly formatted response for zip that could be in multiple districts', function testSlash(done) {
           stubRequest(validApiURL, fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS);
 
           supertest(this.server)
             .get('/api/district-from-address?zip=20500')
             .expect(200, fixtures.TWO_DISTRICTS_RESPONSE, done);
+        });
+
+        it('returns correctly formatted response for zip in state with a single at-large district', function testSlash(done) {
+          stubRequest(validApiURL, fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS);
+
+          supertest(this.server)
+            .get('/api/district-from-address?zip=20500')
+            .expect(200, fixtures.TWO_DISTRICTS_RESPONSE, done);
+        });
+
+        it('with successful API calls, returns correctly formatted response with two districts', function testSlash(done) {
+          stubRequest(validApiURL, fixtures.ZIP_ONLY_WITH_AT_LARGE_DISTRICT);
+
+          supertest(this.server)
+            .get('/api/district-from-address?zip=20500')
+            .expect(200, fixtures.AT_LARGE_DISTRICT_RESPONSE, done);
         });
 
         it('with failed API calls, returns correctly formatted error response', function testSlash(done) {


### PR DESCRIPTION
Previously, CallMyCongress.com did not correctly handle states
with a single, at-large congressional district and always expected
the underlying API responses to return at least one congressional
district per response. This commit fixes those assumptions for
both searching by zip only as well as searching by full address.