### PR TITLE
Resolves #15. Move lookup data into global service.

### DIFF
--- a/app/components/display-congress.js
+++ b/app/components/display-congress.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   classNames: ['display-congress'],
   message: Ember.inject.service(),
+  lookupData: Ember.inject.service(),
 
   congress: null,
 
@@ -22,6 +23,7 @@ export default Ember.Component.extend({
   actions: {
     returnHome() {
       this.get('message').clear();
+      this.get('lookupData').clear();
       this.get('router').transitionTo('index');
     }
   }

--- a/app/components/lookup-congress.js
+++ b/app/components/lookup-congress.js
@@ -3,15 +3,11 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   message: Ember.inject.service(),
-
-  street: null,
-  zip: null,
-
-  districtsToPickFrom: null,
+  lookupData: Ember.inject.service(),
 
   lookupDistrict() {
-    const street = this.get('street');
-    const zip = this.get('zip');
+    const street = this.get('lookupData.street');
+    const zip = this.get('lookupData.zip');
 
     let url;
 
@@ -29,7 +25,7 @@ export default Ember.Component.extend({
             this.get('router').transitionTo('district', result.districts[0].id);
             return;
           } else if (result.districts.length > 1) {
-            this.set('districtsToPickFrom', result.districts);
+            this.set('lookupData.districtsToPickFrom', result.districts);
             return;
           }
         }
@@ -45,7 +41,7 @@ export default Ember.Component.extend({
     event.preventDefault();
     this.get('message').clear();
 
-    if (this.get('zip') === null) {
+    if (Ember.isNone(this.get('lookupData.zip'))) {
       this.get('message').display('errors.server.MISSING_ZIP');
       return;
     }

--- a/app/services/lookup-data.js
+++ b/app/services/lookup-data.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  street: null,
+  zip: null,
+  districtsToPickFrom: null,
+
+  clear() {
+    this.setProperties({
+      street: null,
+      zip: null,
+      districtsToPickFrom: null
+    });
+  }
+});

--- a/app/templates/components/lookup-congress.hbs
+++ b/app/templates/components/lookup-congress.hbs
@@ -2,14 +2,14 @@
    <div class="row">
     <div class="six columns lookup-congress__street">
       <label for="addressInput">{{t "geography.address"}}</label>
-      {{input value=street
+      {{input value=lookupData.street
               placeholder="1600 Pennsylvania Ave"
               id="addressInput"
               class="u-full-width"}}
     </div>
     <div class="six columns lookup-congress__zip">
       <label for="zipCodeInput">{{t "geography.zipCode"}}</label>
-      {{input value=zip
+      {{input value=lookupData.zip
               placeholder="20500"
               id="zipCodeInput"
               class="u-full-width"
@@ -25,6 +25,6 @@
   </div>
 </form>
 
-{{#if districtsToPickFrom}}
-  {{pick-district districts=districtsToPickFrom}}
+{{#if lookupData.districtsToPickFrom}}
+  {{pick-district districts=lookupData.districtsToPickFrom}}
 {{/if}}

--- a/tests/integration/components/lookup-congress-test.js
+++ b/tests/integration/components/lookup-congress-test.js
@@ -17,8 +17,8 @@ test('it renders', function(assert) {
 });
 
 test('renders pick-district component when multiple districts', function(assert) {
-  this.set('districts', MULTIPLE_DISTRICTS.districts);
-  this.render(hbs`{{lookup-congress districtsToPickFrom=districts}}`);
+  this.set('lookupData', { districtsToPickFrom: MULTIPLE_DISTRICTS.districts });
+  this.render(hbs`{{lookup-congress lookupData=lookupData}}`);
 
   assert.equal(this.$('.pick-district').length, 1, 'renders pick-district');
 });

--- a/tests/unit/components/lookup-congress-test.js
+++ b/tests/unit/components/lookup-congress-test.js
@@ -20,6 +20,8 @@ moduleForComponent('lookup-congress', 'Unit | Component | lookup congress', {
         name: 'message',
         methods: ['clear', 'display', 'displayFromServer']
       }, {
+        name: 'lookupData'
+      }, {
         name: 'event',
         methods: ['preventDefault']
       }, {
@@ -40,7 +42,8 @@ moduleForComponent('lookup-congress', 'Unit | Component | lookup congress', {
     this.component = this.subject();
     this.component.setProperties({
       message: this.stubs.objects.message,
-      router: this.stubs.objects.router
+      lookupData: this.stubs.objects.lookupData,
+      router: this.stubs.objects.router,
     });
 
     this.orginalGetJSON = $.getJSON;
@@ -53,7 +56,7 @@ moduleForComponent('lookup-congress', 'Unit | Component | lookup congress', {
 });
 
 test('submit > makes request when street and zip are provided', function(assert) {
-  this.component.setProperties({
+  this.component.set('lookupData', {
     street: STREET,
     zip: ZIP
   });
@@ -75,7 +78,7 @@ test('submit > does not make request unless zip is provided', function(assert) {
   assert.equal(this.stubs.calls.message.display.length, 1, 'displays an error message');
   assert.equal(this.stubs.calls.router.transitionTo.length, 0, 'does not attempt to transition');
 
-  this.component.set('street', '1600 Pennsylvania Ave');
+  this.component.set('lookupData.street', '1600 Pennsylvania Ave');
   this.component.submit(this.stubs.objects.event);
 
   assert.equal(this.stubs.calls.message.clear.length, 2, 'clears any existing messages');
@@ -87,7 +90,7 @@ test('lookupDistrict > transitions when response is successful', function(assert
   this.responseSuccessful = true;
   this.response = SINGLE_DISTRICT;
 
-  this.component.setProperties({
+  this.component.setProperties('lookupData', {
     street: STREET,
     zip: ZIP
   });
@@ -105,7 +108,7 @@ test('lookupDistrict > transitions when response is successful with only zip', f
   this.responseSuccessful = true;
   this.response = SINGLE_DISTRICT;
 
-  this.component.setProperties({
+  this.component.setProperties('lookupData', {
     zip: ZIP
   });
 
@@ -122,14 +125,14 @@ test('lookupDistrict > sets districtsToPickFrom when multiple districts per zip'
   this.responseSuccessful = true;
   this.response = MULTIPLE_DISTRICTS;
 
-  this.component.setProperties({
+  this.component.setProperties('lookupData', {
     zip: ZIP
   });
 
   const done = assert.async();
 
   this.component.lookupDistrict().then(() => {
-    assert.deepEqual(this.component.get('districtsToPickFrom'), MULTIPLE_DISTRICTS.districts);
+    assert.deepEqual(this.component.get('lookupData.districtsToPickFrom'), MULTIPLE_DISTRICTS.districts);
     assert.equal(this.stubs.calls.router.transitionTo.length, 0, 'does not call calls router.transitionTo');
     done();
   });
@@ -139,7 +142,7 @@ test('lookupDistrict > shows error when response is malformed', function(assert)
   this.responseSuccessful = true;
   this.response = 'this is an invalid response';
 
-  this.component.setProperties({
+  this.component.setProperties('lookupData', {
     street: STREET,
     zip: ZIP
   });
@@ -157,7 +160,7 @@ test('lookupDistrict > shows error when response fails', function(assert) {
   this.responseSuccessful = false;
   this.response = 'some error';
 
-  this.component.setProperties({
+  this.component.setProperties('lookupData', {
     street: STREET,
     zip: ZIP
   });


### PR DESCRIPTION
Move lookup data (street, zip, and possible districts) into global service. This allows the back button to function as expected when looking at multiple possible districts from a single search result. In order to maintain original functionality of Search Again button, also ensure that any previous search data is cleared when that button is pressed.