### PR TITLE
Move description from random div to proper meta description tag.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Call My Congress</title>
-    <meta name="description" content="">
+    <meta name="description" content="Find your representatives and senators with just a zip code. Call your elected officials in Congress or check their voting records . Make your voice heard.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -40,11 +40,5 @@
     <script src="{{rootURL}}assets/call-my-congress.js"></script>
 
     {{content-for "body-footer"}}
-
-    <div style="visibility: hidden; height: 0">
-        Find your representatives and senators quickly and easily.
-        Call your elected officials in Congress or check their voting records.
-        Contact your legislators and make sure your voice is heard.
-    </div>
   </body>
 </html>


### PR DESCRIPTION
In order to improve display in search results, the site description should be in a `meta` tag, instead of hiding in some random invisible `div` on the page.