### PR TITLE
Resolves #10. Add loading spinner to search page.

### DIFF
--- a/app/components/lookup-congress.js
+++ b/app/components/lookup-congress.js
@@ -5,6 +5,8 @@ export default Ember.Component.extend({
   message: Ember.inject.service(),
   lookupData: Ember.inject.service(),
 
+  isLoading: false,
+
   lookupDistrict() {
     const street = this.get('lookupData.street');
     const zip = this.get('lookupData.zip');
@@ -18,8 +20,11 @@ export default Ember.Component.extend({
       url = `/api/district-from-address?zip=${zip}`;
     }
 
+    this.set('isLoading', true);
+
     return $.getJSON(url)
       .then(result => {
+        this.set('isLoading', false);
         if (result.districts) {
           if (result.districts.length === 1) {
             this.get('router').transitionTo('district', result.districts[0].id);
@@ -33,6 +38,7 @@ export default Ember.Component.extend({
         this.get('message').display('errors.general');
       })
       .catch(error => {
+        this.set('isLoading', false);
         this.get('message').displayFromServer(error);
       });
   },

--- a/app/templates/components/lookup-congress.hbs
+++ b/app/templates/components/lookup-congress.hbs
@@ -25,6 +25,10 @@
   </div>
 </form>
 
+{{#if isLoading}}
+  <img class="loading loading--nested" src="/assets/loading.svg" />
+{{/if}}
+
 {{#if lookupData.districtsToPickFrom}}
   {{pick-district districts=lookupData.districtsToPickFrom}}
 {{/if}}

--- a/public/assets/call-my-congress.css
+++ b/public/assets/call-my-congress.css
@@ -91,6 +91,10 @@ body {
   max-width: 75px;
 }
 
+.loading--nested {
+  margin: var(--padding--large) auto;
+}
+
 /* Override default skeleton.css button colors. */
 .button.button-primary,
 button.button-primary,


### PR DESCRIPTION
Currently, when you search for an address or zip code, there is no immediate loading feedback. This commit adds a loading spinner to the bottom of the page while the lookup request is processing.

<img width="1430" alt="callmycongress_10_loading-spinner" src="https://cloud.githubusercontent.com/assets/4974085/21583702/74abbd1e-d041-11e6-9a5e-d21197962ee9.png">
