### PR TITLE
Add support for non-voting delegate districts.

### DIFF
--- a/app/components/display-congress.js
+++ b/app/components/display-congress.js
@@ -10,10 +10,14 @@ export default Ember.Component.extend({
   // We can assume only one district per congress response from the server
   district: Ember.computed.alias('congress.district.districts.firstObject'),
 
-  successfulLoad: Ember.computed.and(
-    'district.id',
+  hasRepresentativesOrSenators: Ember.computed.or(
     'congress.representatives.length',
     'congress.senators.length'
+  ),
+
+  successfulLoad: Ember.computed.and(
+    'district.id',
+    'hasRepresentativesOrSenators'
   ),
 
   permalink: Ember.computed('district.id', function() {

--- a/backend/app/non-voting-districts.js
+++ b/backend/app/non-voting-districts.js
@@ -1,0 +1,57 @@
+/* jshint node: true */
+
+const AMERICAN_SAMOA_CODE = 'AS';
+const GUAM_CODE = 'GU';
+const NORTHERN_MARIANA_ISLANDS_CODE = 'MP';
+const PUERTO_RICO_CODE = 'PR';
+const US_VIRGIN_ISLANDS_CODE = 'VI';
+const WASHINGTON_DC_CODE = 'DC';
+
+/**
+ * Given a zip code, return the USPS abbreviation of the non-voting congressional
+ * district to which it belongs. If none, return null.
+ *
+ * @param  {number} zipCode The numeric zip code (postal code) to check.
+ * @return {?string}        Two-digit USPS abbreviation, or null.
+ */
+function zipCodeToNonVotingUSPSCode(zipCode) {
+  const inRange = (min, max) => zipCode >= min && zipCode <= max;
+
+  // Washington DC: 20001-20098, 20201-20599
+  if (inRange(20001, 20008) || inRange(20201, 20599)) {
+    return WASHINGTON_DC_CODE;
+  }
+
+  // Puerto Rico: 00600-00799, 00900-00999
+  if (inRange(600, 799) || inRange(900, 999)) {
+    return PUERTO_RICO_CODE;
+  }
+
+  // American Samoa: 96799
+  if (zipCode === 96799) {
+    return AMERICAN_SAMOA_CODE;
+  }
+
+  // Guam: 96910–96932
+  if (inRange(96910, 96932)) {
+    return GUAM_CODE;
+  }
+
+  // Northern Mariana Islands: 96950–96952
+  if (inRange(96950, 96952)) {
+    return NORTHERN_MARIANA_ISLANDS_CODE;
+  }
+
+  // US Virgin Islands:
+  // 00801–00805, 00820–00824, 00830–00831, 00840–00841, 00850–00851
+  if (inRange(801, 805) || inRange(820, 824) || inRange(830, 831) ||
+      inRange(840, 841) || inRange(850, 851)) {
+    return US_VIRGIN_ISLANDS_CODE;
+  }
+
+  return null;
+}
+
+module.exports = {
+  zipCodeToNonVotingUSPSCode
+};

--- a/backend/tests/fixtures/api.js
+++ b/backend/tests/fixtures/api.js
@@ -144,6 +144,79 @@ const AT_LARGE_DISTRICT_OBJECT = {
   }
 };
 
+const NON_VOTING_DISTRICT_OBJECT = {
+  result: {
+    input: {
+      address: {
+        street: '1025 5th St',
+        zip: '20001'
+      },
+      benchmark: {
+        id: '4',
+        isDefault: false,
+        benchmarkName: 'Public_AR_Current',
+        benchmarkDescription: 'Public Address Ranges - Current Benchmark'
+      },
+      vintage: {
+        id: '4',
+        isDefault: true,
+        vintageName: 'Current_Current',
+        vintageDescription: 'Current Vintage - Current Benchmark'
+      }
+    },
+    addressMatches: [
+      {
+        geographies: {
+          '115th Congressional Districts': [
+            {
+              OID: 211904692355590,
+              STATE: '11',
+              FUNCSTAT: 'N',
+              NAME: 'Delegate District (at Large)',
+              AREAWATER: 18633403,
+              CDSESSN: '115',
+              LSADC: 'C4',
+              CENTLON: '-077.0162745',
+              BASENAME: 'Delegate District (at Large)',
+              INTPTLAT: '+38.9041031',
+              MTFCC: 'G5200',
+              GEOID: '1198',
+              CENTLAT: '+38.9047579',
+              CD115: '98',
+              INTPTLON: '-077.0172290',
+              AREALAND: 158364994,
+              OBJECTID: 264
+            }
+          ]
+        },
+        matchedAddress: '1025 5TH ST NW, WASHINGTON, DC, 20001',
+        coordinates: {
+          x: -77.01892,
+          y: 38.903103
+        },
+        tigerLine: {
+          side: 'R',
+          tigerLineId: '638666952'
+        },
+        addressComponents: {
+          fromAddress: '1001',
+          toAddress: '1051',
+          preQualifier: '',
+          preDirection: '',
+          preType: '',
+          streetName: '5TH',
+          suffixType: 'ST',
+          suffixDirection: 'NW',
+          suffixQualifier: '',
+          state: 'DC',
+          zip: '20001',
+          city: 'WASHINGTON'
+        }
+      }
+    ]
+  }
+};
+
 const ZIP_ONLY_DISTRICT_OBJECT = {
   results: [
     {
@@ -419,6 +492,7 @@ const REPRESENTATIVE_OBJECT = {
 
 const DISTRICT = JSON.stringify(DISTRICT_OBJECT);
 const AT_LARGE_DISTRICT = JSON.stringify(AT_LARGE_DISTRICT_OBJECT);
+const NON_VOTING_DISTRICT = JSON.stringify(NON_VOTING_DISTRICT_OBJECT);
 const ZIP_ONLY_DISTRICT = JSON.stringify(ZIP_ONLY_DISTRICT_OBJECT);
 const ZIP_ONLY_WITH_TWO_DISTRICTS = JSON.stringify(ZIP_ONLY_WITH_TWO_DISTRICTS_OBJECT);
 const ZIP_ONLY_WITH_AT_LARGE_DISTRICT = JSON.stringify(ZIP_ONLY_WITH_AT_LARGE_DISTRICT_OBJECT);
@@ -460,6 +534,16 @@ const AT_LARGE_DISTRICT_RESPONSE = {
   ]
 };
 
+const NON_VOTING_DISTRICT_RESPONSE = {
+  districts: [
+    {
+      state: 'DC',
+      number: '0',
+      id: 'DC-0'
+    }
+  ]
+};
+
 const CONGRESS_RESPONSE = {
   district: DISTRICT_RESPONSE,
   representatives: REPRESENTATIVE_OBJECT.objects,
@@ -469,6 +553,7 @@ const CONGRESS_RESPONSE = {
 module.exports = {
   DISTRICT,
   AT_LARGE_DISTRICT,
+  NON_VOTING_DISTRICT,
   ZIP_ONLY_DISTRICT,
   ZIP_ONLY_WITH_TWO_DISTRICTS,
   ZIP_ONLY_WITH_AT_LARGE_DISTRICT,
@@ -477,5 +562,6 @@ module.exports = {
   DISTRICT_RESPONSE,
   TWO_DISTRICTS_RESPONSE,
   AT_LARGE_DISTRICT_RESPONSE,
+  NON_VOTING_DISTRICT_RESPONSE,
   CONGRESS_RESPONSE
 };

--- a/backend/tests/non-voting-districts-test.js
+++ b/backend/tests/non-voting-districts-test.js
@@ -1,0 +1,15 @@
+const { zipCodeToNonVotingUSPSCode } = require('../app/non-voting-districts');
+const assert = require('assert');
+
+describe('zipCodeToNonVotingUSPSCode', function() {
+  describe('with valid input', function() {
+    it('returns the correct abbreviation', function() {
+      assert.equal(zipCodeToNonVotingUSPSCode(96799), 'AS', 'zip code matches exactly');
+      assert.equal(zipCodeToNonVotingUSPSCode(20001), 'DC', 'zip code at start of range');
+      assert.equal(zipCodeToNonVotingUSPSCode(799),   'PR', 'zip code at end of range');
+      assert.equal(zipCodeToNonVotingUSPSCode(96930), 'GU', 'zip code inside of range');
+      assert.equal(zipCodeToNonVotingUSPSCode(96953), null, 'zip code at range + 1');
+      assert.equal(zipCodeToNonVotingUSPSCode(91403), null, 'zip code does not match any non-voting districts');
+    });
+  });
+});

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -38,80 +38,82 @@ describe('server', function() {
 
   describe('/api/district-from-address', function() {
     describe('with valid params', function() {
-      const validApiURL = 'https://geocoding.geo.census.gov/geocoder/geographies/address?benchmark=Public_AR_Current&vintage=Current_Current&format=json&layers=54&street=1600%20Pennsylvania%20Ave&zip=20500';
+      const apiURL = 'https://geocoding.geo.census.gov/geocoder/geographies/address?benchmark=Public_AR_Current&vintage=Current_Current&format=json&layers=54&street=1600%20Pennsylvania%20Ave&zip=20500';
+      const serverURL = '/api/district-from-address?street=1600%20Pennsylvania%20Ave&zip=20500';
 
       it('with successful API calls, returns correctly formatted response', function testSlash(done) {
-        stubRequest(validApiURL, fixtures.DISTRICT);
+        stubRequest(apiURL, fixtures.DISTRICT);
 
         supertest(this.server)
-          .get('/api/district-from-address?street=1600%20Pennsylvania%20Ave&zip=20500')
+          .get(serverURL)
           .expect(200, fixtures.DISTRICT_RESPONSE, done);
       });
 
       it('returns correctly formatted response for address that in state with a single at-large district', function testSlash(done) {
-        stubRequest(validApiURL, fixtures.AT_LARGE_DISTRICT);
+        stubRequest(apiURL, fixtures.AT_LARGE_DISTRICT);
 
         supertest(this.server)
-          .get('/api/district-from-address?street=1600%20Pennsylvania%20Ave&zip=20500')
+          .get(serverURL)
           .expect(200, fixtures.AT_LARGE_DISTRICT_RESPONSE, done);
       });
 
       it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
-        stubRequest(validApiURL, { message: 'failed with some error' }, true);
+        stubRequest(apiURL, { message: 'failed with some error' }, true);
 
         supertest(this.server)
-          .get('/api/district-from-address?street=1600%20Pennsylvania%20Ave&zip=20500')
+          .get(serverURL)
           .expect(500, { translationKey: 'UNKNOWN' }, done);
       });
 
       it('with invalid API calls, returns correctly formatted error response', function testSlash(done) {
-        stubRequest(validApiURL, 'unexpected successful response type');
+        stubRequest(apiURL, 'unexpected successful response type');
 
         supertest(this.server)
-          .get('/api/district-from-address?street=1600%20Pennsylvania%20Ave&zip=20500')
+          .get(serverURL)
           .expect(500, { translationKey: 'UNKNOWN' }, done);
       });
 
       describe('providing only zip code', function() {
-        const validApiURL = 'http://whoismyrepresentative.com/getall_mems.php?output=json&zip=20500';
+        const apiURL = 'http://whoismyrepresentative.com/getall_mems.php?output=json&zip=20500';
+        const serverURL = '/api/district-from-address?zip=20500';
 
         it('with successful API calls, returns correctly formatted response', function testSlash(done) {
-          stubRequest(validApiURL, fixtures.ZIP_ONLY_DISTRICT);
+          stubRequest(apiURL, fixtures.ZIP_ONLY_DISTRICT);
 
           supertest(this.server)
-            .get('/api/district-from-address?zip=20500')
+            .get(serverURL)
             .expect(200, fixtures.DISTRICT_RESPONSE, done);
         });
 
         it('returns correctly formatted response for zip that could be in multiple districts', function testSlash(done) {
-          stubRequest(validApiURL, fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS);
+          stubRequest(apiURL, fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS);
 
           supertest(this.server)
-            .get('/api/district-from-address?zip=20500')
+            .get(serverURL)
             .expect(200, fixtures.TWO_DISTRICTS_RESPONSE, done);
         });
 
         it('returns correctly formatted response for zip in state with a single at-large district', function testSlash(done) {
-          stubRequest(validApiURL, fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS);
+          stubRequest(apiURL, fixtures.ZIP_ONLY_WITH_TWO_DISTRICTS);
 
           supertest(this.server)
-            .get('/api/district-from-address?zip=20500')
+            .get(serverURL)
             .expect(200, fixtures.TWO_DISTRICTS_RESPONSE, done);
         });
 
         it('with successful API calls, returns correctly formatted response with two districts', function testSlash(done) {
-          stubRequest(validApiURL, fixtures.ZIP_ONLY_WITH_AT_LARGE_DISTRICT);
+          stubRequest(apiURL, fixtures.ZIP_ONLY_WITH_AT_LARGE_DISTRICT);
 
           supertest(this.server)
-            .get('/api/district-from-address?zip=20500')
+            .get(serverURL)
             .expect(200, fixtures.AT_LARGE_DISTRICT_RESPONSE, done);
         });
 
         it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
-          stubRequest(validApiURL, `<result message='No Data Found' />`);
+          stubRequest(apiURL, `<result message='No Data Found' />`);
 
           supertest(this.server)
-            .get('/api/district-from-address?zip=20500')
+            .get(serverURL)
             .expect(500, { translationKey: 'INVALID_ADDRESS' }, done);
         });
       });
@@ -135,13 +137,15 @@ describe('server', function() {
   describe('/api/congress-from-district', function() {
     const validRepresentativeURL = 'https://www.govtrack.us/api/v2/role?current=true&district=12&state=CA';
     const validSenatorURL = 'https://www.govtrack.us/api/v2/role?current=true&role_type=senator&state=CA';
+    const serverURL = '/api/congress-from-district?id=CA-12';
+
     describe('with valid params', function() {
       it('with successful API calls, returns correctly formatted response', function testSlash(done) {
         stubRequest(validRepresentativeURL, fixtures.REPRESENTATIVE);
         stubRequest(validSenatorURL, fixtures.SENATORS);
 
         supertest(this.server)
-          .get('/api/congress-from-district?id=CA-12')
+          .get(serverURL)
           .expect(200, fixtures.CONGRESS_RESPONSE, done);
       });
 
@@ -150,7 +154,7 @@ describe('server', function() {
         stubRequest(validSenatorURL, { message: 'another error' }, true);
 
         supertest(this.server)
-          .get('/api/congress-from-district?id=CA-12')
+          .get(serverURL)
           .expect(500, { translationKey: 'UNKNOWN' }, done);
       });
 
@@ -159,7 +163,7 @@ describe('server', function() {
         stubRequest(validSenatorURL, 'unexpected error response type', true);
 
         supertest(this.server)
-          .get('/api/congress-from-district?id=CA-12')
+          .get(serverURL)
           .expect(500, { translationKey: 'UNKNOWN' }, done);
       });
     });

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -57,6 +57,14 @@ describe('server', function() {
           .expect(200, fixtures.AT_LARGE_DISTRICT_RESPONSE, done);
       });
 
+      it('returns correctly formatted response for address that in non-voting district', function testSlash(done) {
+        stubRequest(apiURL, fixtures.NON_VOTING_DISTRICT);
+
+        supertest(this.server)
+          .get(serverURL)
+          .expect(200, fixtures.NON_VOTING_DISTRICT_RESPONSE, done);
+      });
+
       it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
         stubRequest(apiURL, { message: 'failed with some error' }, true);
 
@@ -110,11 +118,20 @@ describe('server', function() {
         });
 
         it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
+          stubRequest('http://whoismyrepresentative.com/getall_mems.php?output=json&zip=99999',
+                      `<result message='No Data Found' />`);
+
+          supertest(this.server)
+            .get('/api/district-from-address?zip=99999')
+            .expect(500, { translationKey: 'INVALID_ADDRESS' }, done);
+        });
+
+        it('with failed API calls, matching a non-voting district, returns correctly formatted response', function testSlash(done) {
           stubRequest(apiURL, `<result message='No Data Found' />`);
 
           supertest(this.server)
             .get(serverURL)
-            .expect(500, { translationKey: 'INVALID_ADDRESS' }, done);
+            .expect(200, fixtures.NON_VOTING_DISTRICT_RESPONSE, done);
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "backend": "PORT=3000 nodemon backend/app/server.js",
     "frontend": "ember server --proxy http://127.0.0.1:3000",
 
-    "test:backend": "mocha -R spec backend/tests/server-test.js",
+    "test:backend": "mocha -R spec backend/tests/*-test.js",
     "test:frontend": "ember test",
 
-    "test-server:backend": "mocha -R spec backend/tests/server-test.js -w",
+    "test-server:backend": "mocha -R spec backend/tests/*-test.js -w",
     "test-server:frontend": "ember test --serve"
   },
   "repository": "",

--- a/tests/fixtures/congress.js
+++ b/tests/fixtures/congress.js
@@ -335,7 +335,7 @@ export const NO_DISTRICT = {
   ]
 };
 
-export const NO_REPRESENTATIVES =  {
+export const NO_REPRESENTATIVES_OR_SENATORS =  {
   district: {
     districts: [
       {
@@ -344,116 +344,7 @@ export const NO_REPRESENTATIVES =  {
         state: "CA"
       }
     ]
-  },
-  senators: [
-    {
-      caucus: null,
-      congress_numbers: [
-        112,
-        113,
-        114
-      ],
-      current: true,
-      description: "Junior Senator from California",
-      district: null,
-      enddate: "2017-01-03",
-      extra: {
-        address: "112 Hart Senate Office Building Washington DC 20510",
-        contact_form: "https://www.boxer.senate.gov/contact/shareyourviews.html",
-        fax: "202-224-0454",
-        office: "112 Hart Senate Office Building"
-      },
-      id: 3853,
-      leadership_title: null,
-      party: "Democrat",
-      person: {
-        bioguideid: "B000711",
-        birthday: "1940-11-11",
-        cspanid: 2470,
-        firstname: "Barbara",
-        gender: "female",
-        gender_label: "Female",
-        id: 300011,
-        lastname: "Boxer",
-        link: "https://www.govtrack.us/congress/members/barbara_boxer/300011",
-        middlename: "",
-        name: "Sen. Barbara Boxer [D-CA]",
-        namemod: "",
-        nickname: "",
-        osid: "N00006692",
-        pvsid: "53274",
-        sortname: "Boxer, Barbara (Sen.) [D-CA]",
-        twitterid: "SenatorBoxer",
-        youtubeid: "SenatorBoxer"
-      },
-      phone: "202-224-3553",
-      role_type: "senator",
-      role_type_label: "Senator",
-      senator_class: "class3",
-      senator_class_label: "Class 3",
-      senator_rank: "junior",
-      senator_rank_label: "Junior",
-      startdate: "2011-01-05",
-      state: "CA",
-      title: "Sen.",
-      title_long: "Senator",
-      website: "https://www.boxer.senate.gov"
-    },
-    {
-      caucus: null,
-      congress_numbers: [
-        113,
-        114,
-        115
-      ],
-      current: true,
-      description: "Senior Senator from California",
-      district: null,
-      enddate: "2019-01-03",
-      extra: {
-        address: "331 Hart Senate Office Building Washington DC 20510",
-        contact_form: "https://www.feinstein.senate.gov/public/index.cfm/e-mail-me",
-        fax: "202-228-3954",
-        office: "331 Hart Senate Office Building",
-        rss_url: "http://www.feinstein.senate.gov/public/?a=rss.feed"
-      },
-      id: 42868,
-      leadership_title: null,
-      party: "Democrat",
-      person: {
-        bioguideid: "F000062",
-        birthday: "1933-06-22",
-        cspanid: 13061,
-        firstname: "Dianne",
-        gender: "female",
-        gender_label: "Female",
-        id: 300043,
-        lastname: "Feinstein",
-        link: "https://www.govtrack.us/congress/members/dianne_feinstein/300043",
-        middlename: "",
-        name: "Sen. Dianne Feinstein [D-CA]",
-        namemod: "",
-        nickname: "",
-        osid: "N00007364",
-        pvsid: "53273",
-        sortname: "Feinstein, Dianne (Sen.) [D-CA]",
-        twitterid: "SenFeinstein",
-        youtubeid: "SenatorFeinstein"
-      },
-      phone: "202-224-3841",
-      role_type: "senator",
-      role_type_label: "Senator",
-      senator_class: "class1",
-      senator_class_label: "Class 1",
-      senator_rank: "senior",
-      senator_rank_label: "Senior",
-      startdate: "2013-01-03",
-      state: "CA",
-      title: "Sen.",
-      title_long: "Senator",
-      website: "http://www.feinstein.senate.gov"
-    }
-  ]
+  }
 };
 
 export const NO_SENATORS = {

--- a/tests/integration/components/display-congress-test.js
+++ b/tests/integration/components/display-congress-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import {
   COMPLETE_CONGRESS,
   NO_DISTRICT,
-  NO_REPRESENTATIVES,
+  NO_REPRESENTATIVES_OR_SENATORS,
   NO_SENATORS
 } from '../../fixtures/congress';
 import hbs from 'htmlbars-inline-precompile';
@@ -47,6 +47,19 @@ test('back button', function(assert) {
   assert.deepEqual(this.stubs.calls.router.transitionTo[0], ['index'], 'router.transitionTo was called with "index"');
 });
 
+test('with partial data, it renders', function(assert) {
+  this.set('congress', NO_SENATORS);
+  this.render(hbs`{{display-congress congress=congress}}`);
+
+  assert.ok(this.$('.display-congress__state').text().match('CA'), 'renders the state');
+  assert.ok(this.$('.display-congress__district').text().match('12'), 'renders the district number');
+  assert.ok(this.$('.display-congress__permalink').text().match('CA-12'), 'renders the permalink');
+
+  assert.equal(this.$('.display-congressperson').length, 1, 'renders the representative');
+
+  assert.equal(this.$('.display-congress__back').length, 1, 'renders back button');
+});
+
 function testIncompleteFixture(fixture) {
   test('it handles incomplete data', function(assert) {
     this.set('congress', fixture);
@@ -59,5 +72,4 @@ function testIncompleteFixture(fixture) {
 }
 
 testIncompleteFixture(NO_DISTRICT);
-testIncompleteFixture(NO_REPRESENTATIVES);
-testIncompleteFixture(NO_SENATORS);
+testIncompleteFixture(NO_REPRESENTATIVES_OR_SENATORS);


### PR DESCRIPTION
<img width="1428" alt="screen shot 2017-01-06 at 10 53 03 pm" src="https://cloud.githubusercontent.com/assets/4974085/21740091/eeb94462-d462-11e6-996b-1a67f8226d38.png">

Resolves #21. Adds support for non-voting districts.

There are six non-voting delegate districts in the House of Reps: Washington DC, Puerto Rico, American Samoa, Guam, the Northern Mariana Islands, and the US Virgin Islands. Ensure that these six districts can also look up their congressional representatives.

The street address API from US Census already correctly handles these districts, but the district name didn't quite match the existing check for at-large congressional districts. However, whoismyrepresentative's API (used for zip-only look ups) does not recognize non-voting districts. I added manual maps of zip codes to USPS codes for each of these six districts, sourced from Wikipedia. This will do for now, but I would love to replace this with either an API or a library or some other more maintainable solution moving forward.