### PR TITLE
Update zip-only response to handle API changes.

### DIFF
--- a/backend/app/server.js
+++ b/backend/app/server.js
@@ -96,7 +96,7 @@ function getDistrictsZipOnly(geography) {
     const districtNumbers = result.results
       .map(representative => representative.district)
       // Filter out all non-numeric districts (i.e. "Junior Seat" for senators)
-      .filter(district => !isNaN(district));
+      .filter(district => district && !isNaN(district));
 
     if (state && districtNumbers.length === 0) {
       districtNumbers.push(AT_LARGE_DISTRICT_NUMBER);

--- a/backend/tests/fixtures/api.js
+++ b/backend/tests/fixtures/api.js
@@ -238,7 +238,7 @@ const ZIP_ONLY_DISTRICT_OBJECT = {
       state: 'CA'
     },
     {
-      district: 'Senior Seat',
+      district: '',
       link: 'http://www.feinstein.senate.gov',
       name: 'Dianne Feinstein',
       office: '331 Hart Senate Office Building',
@@ -279,7 +279,7 @@ const ZIP_ONLY_WITH_TWO_DISTRICTS_OBJECT = {
       state: 'TX'
     },
     {
-      district: 'Junior Seat',
+      district: '',
       link: 'http://www.cruz.senate.gov',
       name: 'Ted Cruz',
       office: '404 Russell Senate Office Building',


### PR DESCRIPTION
whoismyrepresentative's API changed and senator districts can now include empty strings. Update response from server to account for this, and prevent returning empty district objects.