### PR TITLE
Remove zip-only option as whoismyrepresentative is no longer online.

### DIFF
--- a/app/components/lookup-congress.js
+++ b/app/components/lookup-congress.js
@@ -52,6 +52,11 @@ export default Ember.Component.extend({
       return;
     }
 
+    if (Ember.isNone(this.get('lookupData.street'))) {
+      this.get('message').display('errors.server.MISSING_STREET');
+      return;
+    }
+
     this.lookupDistrict();
   }
 });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -22,7 +22,7 @@ export default {
   },
 
   geography: {
-    address: 'Street Address (optional)',
+    address: 'Street Address',
     district: 'Congressional District',
     state: 'State',
     zipCode: 'Zip Code'
@@ -46,6 +46,7 @@ export default {
       INVALID_DISTRICT_ID: 'Provided URL does not map to a valid state and district number.',
       INVALID_STATE: 'State abbreviation provided does not match any known states.',
       MISSING_ZIP: 'Please provide a valid zip code.',
+      MISSING_STREET: 'Please provide a street address. CallMyCongress.com no longer supports zip-only searches, as the source of our data for zip code to congressional districts was shut down. We apologize for the inconvenience.',
       MISSING_DISTRICT_ID: 'Please provide a valid district id to look up representatives.',
       UNKNOWN: 'Something went wrong.'
     }

--- a/backend/app/server.js
+++ b/backend/app/server.js
@@ -6,15 +6,8 @@ const express = require('express');
 const querystring = require('querystring');
 const app = express();
 
-const { zipCodeToNonVotingUSPSCode } = require('./non-voting-districts');
-
 const GEOGRAPHY_BASE_URL = 'https://geocoding.geo.census.gov/geocoder/geographies/address';
-const ZIP_ONLY_BASE_URL = 'http://whoismyrepresentative.com/getall_mems.php';
 const ROLE_BASE_URL = 'https://www.govtrack.us/api/v2/role';
-
-// When zip code is not found, the response succeeds with code 200 but the body
-// has this message instead of a JSON object.
-const ZIP_ONLY_ERROR_BODY = `<result message='No Data Found' />`;
 
 const AT_LARGE_DISTRICT_NAME = '(at Large)';
 const AT_LARGE_DISTRICT_NUMBER = 0;
@@ -56,62 +49,6 @@ function performGETRequest(url, processResult, attemptParse = true) {
       }
     });
   });
-}
-
-function getDistrictsZipOnly(geography) {
-  const params = {
-    output: 'json',
-    zip: geography.zip
-  };
-
-  return performGETRequest(buildURL(ZIP_ONLY_BASE_URL, params), body => {
-
-    if (body === ZIP_ONLY_ERROR_BODY) {
-      // Current API used for zip-only addresses does not handle non-voting
-      // congressional districts. Manually verify if the given zip belongs
-      // to a non-voting district, and if so return that district. Otherwise,
-      // zip code does not map to any district and is invalid.
-      const state = zipCodeToNonVotingUSPSCode(geography.zip);
-
-      if (state !== null) {
-        const number = AT_LARGE_DISTRICT_NUMBER;
-
-        return {
-          districts: [
-            {
-              state,
-              number,
-              id: `${state}-${number}`
-            }
-          ]
-        };
-      }
-
-      throw new AppError('INVALID_ADDRESS');
-    }
-
-    const result = JSON.parse(body);
-    const state = result.results[0].state;
-
-    const districtNumbers = result.results
-      .map(representative => representative.district)
-      // Filter out all non-numeric districts (i.e. "Junior Seat" for senators)
-      .filter(district => district && !isNaN(district));
-
-    if (state && districtNumbers.length === 0) {
-      districtNumbers.push(AT_LARGE_DISTRICT_NUMBER);
-    }
-
-    const districts = districtNumbers.map(number => {
-      return {
-        state,
-        number,
-        id: `${state}-${number}`
-      };
-    });
-
-    return { districts };
-  }, false);
 }
 
 function getDistricts(geography) {
@@ -209,10 +146,13 @@ app.get('/api/district-from-address', (req, res) => {
     return;
   }
 
-  const getDistrictsFunction = req.query.street ? getDistricts : getDistrictsZipOnly;
+  if (req.query.street === undefined || req.query.street === null) {
+    res.status(400).send({ translationKey: 'MISSING_STREET' });
+    return;
+  }
 
   try {
-    getDistrictsFunction(req.query)
+    getDistricts(req.query)
       .then(district => res.send(district))
       .catch(err => {
         const translationKey = err instanceof AppError ? err.message : 'UNKNOWN';

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -81,8 +81,9 @@ describe('server', function() {
           .expect(500, { translationKey: 'UNKNOWN' }, done);
       });
 
-      describe('providing only zip code', function() {
-        const apiURL = 'http://whoismyrepresentative.com/getall_mems.php?output=json&zip=20500';
+      /* TODO: If we can find a new source of data for zip-to-congressional-district, re-enable these tests. */
+      describe.skip('providing only zip code', function() {
+        const apiURL = ''; // TODO: replace with new API url if one can be found
         const serverURL = '/api/district-from-address?zip=20500';
 
         it('with successful API calls, returns correctly formatted response', function testSlash(done) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node backend/app/server.js",
     "test": "npm run test:backend && npm run test:frontend",
 
-    "backend": "PORT=3000 nodemon backend/app/server.js",
+    "backend": "PORT=3000 nodemon backend/app/server.js --ignore ./tmp/ --ignore ./app/",
     "frontend": "ember server --proxy http://127.0.0.1:3000",
 
     "test:backend": "mocha -R spec backend/tests/*-test.js",


### PR DESCRIPTION
Previously, we depended on the free API provided by whoismyrepresentative.com to support zip-only lookup. It appears that site is offline completely. Full address lookup is still functional (relies on census APIs).

Provide helpful error messaging if users attempt to search by zip only.