### PR TITLE
Prevent error if representative seat is empty.

### DIFF
--- a/backend/app/server.js
+++ b/backend/app/server.js
@@ -130,10 +130,6 @@ function buildCongress(district) {
       throw new AppError('INVALID_STATE');
     }
 
-    if (representatives.length === 0) {
-      throw new AppError('INVALID_DISTRICT');
-    }
-
     return { representatives, senators, district };
   });
 }


### PR DESCRIPTION
If a representative's seat is vacant, don't throw an error — just return the senators available.

This may mean that if someone uses an invalid district number (e.g. `12345`), the senators will be shown instead of an error message that this district is invalid. I think that's worth the trade-off though.