### PR TITLE
Resolves #11, use US House/Senate APIs directly instead of GovTrack.

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -18,7 +18,11 @@ export default {
 
   displayCongress: {
     back: 'Search Again',
-    permalink: 'Permanent Link to This Page'
+    permalink: 'Permanent Link to This Page',
+    disclaimerTitle: "Where did all the other data go? Can we get more data?",
+    disclaimerBody: `This site previously used data generously provided for free by {{link-govtrack}}GovTrack.us{{/link-govtrack}}, a project run by citizens who care about government transparency.
+      Unfortunately, GovTrack.us is no longer able to support providing other projects with free access to data, but you can still use their site directly to track your representatives' voting records and participation in Congress.
+      CallMyCongress.com now runs entirely off data provided directly by the US Government, which is more limited.`
   },
 
   geography: {
@@ -30,12 +34,11 @@ export default {
 
   congress: {
     partyAffiliation: 'Party Affiliation',
-    votingRecord: 'Voting Record',
-    govTrack: 'GovTrack Record'
+    vacancy: '(Vacant Seat)'
   },
 
   about: {
-    attribution: "This app runs off data made freely available by the {{link-census}}US Census Geocoding Services{{/link-census}} and {{link-govtrack}}GovTrack.us{{/link-govtrack}}. It was created by {{link-marie}}Marie Chatfield{{/link-marie}}. View the source code or contribute changes on {{link-github}}GitHub{{/link-github}}."
+    attribution: "This app runs off data made freely available by the {{link-census}}US Census Geocoding Services{{/link-census}}, the {{link-house}}US House of Representatives{{/link-house}}, and the {{link-senate}}US Senate{{/link-senate}}. It was created by {{link-marie}}Marie Chatfield{{/link-marie}}. View the source code or contribute changes on {{link-github}}GitHub{{/link-github}}."
   },
 
   errors: {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -12,7 +12,8 @@
 <div class="footer">
 {{translate-format-link key="about.attribution"
                         links=(hash census="https://geocoding.geo.census.gov/"
-                                    govtrack="https://www.govtrack.us/developers"
+                                    house="https://xml.house.gov/"
+                                    senate="https://www.senate.gov/general/XML.htm"
                                     marie="http://mariechatfield.com/"
                                     github="https://github.com/mchat/call-my-congress")}}
 </div>

--- a/app/templates/components/display-congress.hbs
+++ b/app/templates/components/display-congress.hbs
@@ -28,3 +28,10 @@
 <div class="row--extra-space display-congress__back">
   <button class="button-primary u-full-width" {{action "returnHome"}}>{{t "displayCongress.back"}}</button>
 </div>
+
+<div class="row--extra-space">
+  <p>{{t "displayCongress.disclaimerTitle"}}</p>
+  <small>{{translate-format-link key="displayCongress.disclaimerBody"
+                        links=(hash govtrack="https://www.govtrack.us/")}}</small>
+
+</div>

--- a/app/templates/components/display-congressperson.hbs
+++ b/app/templates/components/display-congressperson.hbs
@@ -1,40 +1,31 @@
 <div class="u-full-width display-congressperson__name">
-  <h5>{{t "format.name" title=congressperson.title
-                        firstName=congressperson.person.firstname
-                        lastName=congressperson.person.lastname}}</h5>
+  {{#if congressperson.vacant}}
+    <h5>{{t "congress.vacancy"}}</h5>
+    <p>{{congressperson.footnote}}</p>
+  {{else}}
+    <h5>{{t "format.name" title=congressperson.title
+                          firstName=congressperson.person.firstname
+                          lastName=congressperson.person.lastname}}</h5>
+  {{/if}}
 </div>
 
-<table class="u-full-width">
-  <tbody>
-    {{#if congressperson.phone}}
-      <tr class="display-congressperson__phone">
-        <td><strong>{{t "general.phone"}}</strong></td>
-        <td>
-         <a href="tel:{{congressperson.phone}}">{{congressperson.phone}}</a>
-        </td>
+{{#unless congressperson.vacant}}
+  <table class="u-full-width">
+    <tbody>
+      {{#if congressperson.phone}}
+        <tr class="display-congressperson__phone">
+          <td><strong>{{t "general.phone"}}</strong></td>
+          <td>
+           <a href="tel:{{congressperson.phone}}">{{congressperson.phone}}</a>
+          </td>
+        </tr>
+      {{/if}}
+      {{#if congressperson.party}}
+      <tr class="display-congressperson__party">
+        <td><strong>{{t "congress.partyAffiliation"}}</strong></td>
+        <td>{{congressperson.party}}</td>
       </tr>
-    {{/if}}
-    {{#if congressperson.person.twitterid}}
-    <tr class="display-congressperson__twitter">
-      <td><strong>{{t "general.twitter"}}</strong></td>
-      <td>
-        <a href="https://twitter.com/{{congressperson.person.twitterid}}" target="_blank">@{{congressperson.person.twitterid}}</a>
-      </td>
-    </tr>
-    {{/if}}
-    {{#if congressperson.party}}
-    <tr class="display-congressperson__party">
-      <td><strong>{{t "congress.partyAffiliation"}}</strong></td>
-      <td>{{congressperson.party}}</td>
-    </tr>
-    {{/if}}
-    {{#if congressperson.person.link}}
-    <tr class="display-congressperson__voting-record">
-      <td><strong>{{t "congress.votingRecord"}}</strong></td>
-      <td>
-        <a class="display-congressperson__voting-record__link" href="{{congressperson.person.link}}" target="_blank">{{t "congress.govTrack"}}</a>
-      </td>
-    </tr>
-    {{/if}}
-  </tbody>
-</table>
+      {{/if}}
+    </tbody>
+  </table>
+{{/unless}}

--- a/backend/tests/fixtures/api.js
+++ b/backend/tests/fixtures/api.js
@@ -1,3 +1,5 @@
+/* jshint node: true */
+
 const DISTRICT_OBJECT = {
   result: {
     addressMatches: [
@@ -313,191 +315,12 @@ const ZIP_ONLY_WITH_AT_LARGE_DISTRICT_OBJECT = {
   ]
 };
 
-const SENATORS_OBJECT = {
- meta: {
-  limit: 100,
-  offset: 0,
-  total_count: 2
- },
- objects: [
-  {
-   caucus: null,
-   congress_numbers: [
-    112,
-    113,
-    114
-   ],
-   current: true,
-   description: 'Junior Senator from California',
-   district: null,
-   enddate: '2017-01-03',
-   extra: {
-    address: '112 Hart Senate Office Building Washington DC 20510',
-    contact_form: 'https://www.boxer.senate.gov/contact/shareyourviews.html',
-    fax: '202-224-0454',
-    office: '112 Hart Senate Office Building'
-   },
-   id: 3853,
-   leadership_title: null,
-   party: 'Democrat',
-   person: {
-    bioguideid: 'B000711',
-    birthday: '1940-11-11',
-    cspanid: 2470,
-    firstname: 'Barbara',
-    gender: 'female',
-    gender_label: 'Female',
-    id: 300011,
-    lastname: 'Boxer',
-    link: 'https://www.govtrack.us/congress/members/barbara_boxer/300011',
-    middlename: '',
-    name: 'Sen. Barbara Boxer [D-CA]',
-    namemod: '',
-    nickname: '',
-    osid: 'N00006692',
-    pvsid: '53274',
-    sortname: 'Boxer, Barbara (Sen.) [D-CA]',
-    twitterid: 'SenatorBoxer',
-    youtubeid: 'SenatorBoxer'
-   },
-   phone: '202-224-3553',
-   role_type: 'senator',
-   role_type_label: 'Senator',
-   senator_class: 'class3',
-   senator_class_label: 'Class 3',
-   senator_rank: 'junior',
-   senator_rank_label: 'Junior',
-   startdate: '2011-01-05',
-   state: 'CA',
-   title: 'Sen.',
-   title_long: 'Senator',
-   website: 'https://www.boxer.senate.gov'
-  },
-  {
-   caucus: null,
-   congress_numbers: [
-    113,
-    114,
-    115
-   ],
-   current: true,
-   description: 'Senior Senator from California',
-   district: null,
-   enddate: '2019-01-03',
-   extra: {
-    address: '331 Hart Senate Office Building Washington DC 20510',
-    contact_form: 'https://www.feinstein.senate.gov/public/index.cfm/e-mail-me',
-    fax: '202-228-3954',
-    office: '331 Hart Senate Office Building',
-    rss_url: 'http://www.feinstein.senate.gov/public/?a=rss.feed'
-   },
-   id: 42868,
-   leadership_title: null,
-   party: 'Democrat',
-   person: {
-    bioguideid: 'F000062',
-    birthday: '1933-06-22',
-    cspanid: 13061,
-    firstname: 'Dianne',
-    gender: 'female',
-    gender_label: 'Female',
-    id: 300043,
-    lastname: 'Feinstein',
-    link: 'https://www.govtrack.us/congress/members/dianne_feinstein/300043',
-    middlename: '',
-    name: 'Sen. Dianne Feinstein [D-CA]',
-    namemod: '',
-    nickname: '',
-    osid: 'N00007364',
-    pvsid: '53273',
-    sortname: 'Feinstein, Dianne (Sen.) [D-CA]',
-    twitterid: 'SenFeinstein',
-    youtubeid: 'SenatorFeinstein'
-   },
-   phone: '202-224-3841',
-   role_type: 'senator',
-   role_type_label: 'Senator',
-   senator_class: 'class1',
-   senator_class_label: 'Class 1',
-   senator_rank: 'senior',
-   senator_rank_label: 'Senior',
-   startdate: '2013-01-03',
-   state: 'CA',
-   title: 'Sen.',
-   title_long: 'Senator',
-   website: 'http://www.feinstein.senate.gov'
-  }
- ]
-};
-
-const REPRESENTATIVE_OBJECT = {
- meta: {
-  limit: 100,
-  offset: 0,
-  total_count: 1
- },
- objects: [
-  {
-   caucus: null,
-   congress_numbers: [
-    114
-   ],
-   current: true,
-   description: `Representative for California's 12th congressional district`,
-   district: 12,
-   enddate: '2017-01-03',
-   extra: {
-    address: '233 Cannon HOB; Washington DC 20515-0512',
-    contact_form: 'http://pelosi.house.gov/contact-me/email-me',
-    fax: '202-225-8259',
-    office: '233 Cannon House Office Building',
-    rss_url: 'http://pelosi.house.gov/atom.xml'
-   },
-   id: 43364,
-   leadership_title: 'Minority Leader',
-   party: 'Democrat',
-   person: {
-    bioguideid: 'P000197',
-    birthday: '1940-03-26',
-    cspanid: 6153,
-    firstname: 'Nancy',
-    gender: 'female',
-    gender_label: 'Female',
-    id: 400314,
-    lastname: 'Pelosi',
-    link: 'https://www.govtrack.us/congress/members/nancy_pelosi/400314',
-    middlename: '',
-    name: 'Rep. Nancy Pelosi [D-CA12]',
-    namemod: '',
-    nickname: '',
-    osid: 'N00007360',
-    pvsid: '26732',
-    sortname: 'Pelosi, Nancy (Rep.) [D-CA12]',
-    twitterid: 'NancyPelosi',
-    youtubeid: 'nancypelosi'
-   },
-   phone: '202-225-4965',
-   role_type: 'representative',
-   role_type_label: 'Representative',
-   senator_class: null,
-   senator_rank: null,
-   startdate: '2015-01-06',
-   state: 'CA',
-   title: 'Rep.',
-   title_long: 'Representative',
-   website: 'http://pelosi.house.gov'
-  }
- ]
-};
-
 const DISTRICT = JSON.stringify(DISTRICT_OBJECT);
 const AT_LARGE_DISTRICT = JSON.stringify(AT_LARGE_DISTRICT_OBJECT);
 const NON_VOTING_DISTRICT = JSON.stringify(NON_VOTING_DISTRICT_OBJECT);
 const ZIP_ONLY_DISTRICT = JSON.stringify(ZIP_ONLY_DISTRICT_OBJECT);
 const ZIP_ONLY_WITH_TWO_DISTRICTS = JSON.stringify(ZIP_ONLY_WITH_TWO_DISTRICTS_OBJECT);
 const ZIP_ONLY_WITH_AT_LARGE_DISTRICT = JSON.stringify(ZIP_ONLY_WITH_AT_LARGE_DISTRICT_OBJECT);
-const SENATORS = JSON.stringify(SENATORS_OBJECT);
-const REPRESENTATIVE = JSON.stringify(REPRESENTATIVE_OBJECT);
 
 const DISTRICT_RESPONSE = {
   districts: [
@@ -546,8 +369,78 @@ const NON_VOTING_DISTRICT_RESPONSE = {
 
 const CONGRESS_RESPONSE = {
   district: DISTRICT_RESPONSE,
-  representatives: REPRESENTATIVE_OBJECT.objects,
-  senators: SENATORS_OBJECT.objects
+  representatives: [
+    {
+      person: {
+        firstname: 'Nancy',
+        lastname: 'Pelosi'
+      },
+      title: 'Rep.',
+      party: 'Democrat',
+      phone: '(202) 225-4965'
+    }
+  ],
+  senators: [
+    {
+      person: {
+        firstname: 'Dianne',
+        lastname: 'Feinstein'
+      },
+      title: 'Sen.',
+      party: 'Democrat',
+      phone: '(202) 224-3841'
+    }, {
+      person: {
+        firstname: 'Kamala D.',
+        lastname: 'Harris'
+      },
+      title: 'Sen.',
+      party: 'Democrat',
+      phone: '(202) 224-3553'
+    }
+  ]
+};
+
+const AT_LARGE_CONGRESS_RESPONSE = {
+  district: {
+    districts: [
+      {
+        state: 'AK',
+        number: '0',
+        id: 'AK-0'
+      }
+    ]
+  },
+  representatives: [
+    {
+      person: {
+        firstname: 'Don',
+        lastname: 'Young'
+      },
+      title: 'Rep.',
+      party: 'Republican',
+      phone: '(202) 225-5765'
+    }
+  ],
+  senators: [
+  {
+      person: {
+        firstname: 'Lisa',
+        lastname: 'Murkowski'
+      },
+      title: 'Sen.',
+      party: 'Republican',
+      phone: '(202) 224-6665'
+    }, {
+      person: {
+        firstname: 'Dan',
+        lastname: 'Sullivan'
+      },
+      title: 'Sen.',
+      party: 'Republican',
+      phone: '(202) 224-3004'
+    }
+  ]
 };
 
 module.exports = {
@@ -557,11 +450,10 @@ module.exports = {
   ZIP_ONLY_DISTRICT,
   ZIP_ONLY_WITH_TWO_DISTRICTS,
   ZIP_ONLY_WITH_AT_LARGE_DISTRICT,
-  SENATORS,
-  REPRESENTATIVE,
   DISTRICT_RESPONSE,
   TWO_DISTRICTS_RESPONSE,
   AT_LARGE_DISTRICT_RESPONSE,
   NON_VOTING_DISTRICT_RESPONSE,
-  CONGRESS_RESPONSE
+  CONGRESS_RESPONSE,
+  AT_LARGE_CONGRESS_RESPONSE
 };

--- a/backend/tests/fixtures/house.js
+++ b/backend/tests/fixtures/house.js
@@ -1,0 +1,17465 @@
+/* jshint node: true */
+
+module.exports = {
+  REPRESENTATIVES: `<?xml version="1.0" encoding="UTF-8"?>
+<MemberData publish-date="June 1, 2017">
+    <title-info>
+        <congress-num>115</congress-num>
+        <congress-text>One Hundred Fifteenth Congress</congress-text>
+        <session>1</session>
+        <majority>R</majority>
+        <minority>D</minority>
+        <clerk>Karen L. Haas</clerk>
+        <weburl>http://clerk.house.gov</weburl>
+    </title-info>
+    <members>
+        <member>
+            <statedistrict>AK00</statedistrict>
+            <member-info>
+                <namelist>Young, Don</namelist>
+                <bioguideID>Y000033</bioguideID>
+                <lastname>Young</lastname>
+                <firstname>Don</firstname>
+                <middlename/>
+                <sort-name>YOUNG,DON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Don Young</official-name>
+                <formal-name>Mr. Young of Alaska</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AK">
+                    <state-fullname>Alaska</state-fullname>
+                </state>
+                <district>At Large</district>
+                <townname>Fort Yukon</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2314</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0200</office-zip-suffix>
+                <phone>(202) 225-5765</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="2" />
+                <committee comcode="PW00" rank="2" />
+                <subcommittee subcomcode="II10" rank="2" />
+                <subcommittee subcomcode="II24" rank="2" />
+                <subcommittee subcomcode="PW05" rank="2" />
+                <subcommittee subcomcode="PW07" rank="2" />
+                <subcommittee subcomcode="PW12" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AL01</statedistrict>
+            <member-info>
+                <namelist>Byrne, Bradley</namelist>
+                <bioguideID>B001289</bioguideID>
+                <lastname>Byrne</lastname>
+                <firstname>Bradley</firstname>
+                <middlename/>
+                <sort-name>BYRNE,BRADLEY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bradley Byrne</official-name>
+                <formal-name>Mr. Byrne</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AL">
+                    <state-fullname>Alabama</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Fairhope</townname>
+                <office-building>CHOB</office-building>
+                <office-room>119</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0101</office-zip-suffix>
+                <phone>(202) 225-4931</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="21" />
+                <committee comcode="ED00" rank="11" />
+                <committee comcode="RU00" rank="6" />
+                <subcommittee subcomcode="AS28" rank="4" leadership="Vice Chair" />
+                <subcommittee subcomcode="AS29" rank="9" />
+                <subcommittee subcomcode="ED10" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="ED13" rank="5" />
+                <subcommittee subcomcode="RU02" rank="3" />
+                <subcommittee subcomcode="RU04" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AL02</statedistrict>
+            <member-info>
+                <namelist>Roby, Martha</namelist>
+                <bioguideID>R000591</bioguideID>
+                <lastname>Roby</lastname>
+                <firstname>Martha</firstname>
+                <middlename/>
+                <sort-name>ROBY,MARTHA</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Martha Roby</official-name>
+                <formal-name>Mrs. Roby</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AL">
+                    <state-fullname>Alabama</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Montgomery</townname>
+                <office-building>CHOB</office-building>
+                <office-room>442</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0102</office-zip-suffix>
+                <phone>(202) 225-2901</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="22" />
+                <committee comcode="JU00" rank="20" />
+                <subcommittee subcomcode="AP02" rank="10" />
+                <subcommittee subcomcode="AP07" rank="6" />
+                <subcommittee subcomcode="AP19" rank="5" />
+                <subcommittee subcomcode="JU08" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AL03</statedistrict>
+            <member-info>
+                <namelist>Rogers, Mike</namelist>
+                <bioguideID>R000575</bioguideID>
+                <lastname>Rogers</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>ROGERS,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mike Rogers</official-name>
+                <formal-name>Mr. Rogers of Alabama</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AL">
+                    <state-fullname>Alabama</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Anniston</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2184</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0103</office-zip-suffix>
+                <phone>(202) 225-3261</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="5" />
+                <committee comcode="AS00" rank="7" />
+                <committee comcode="HM00" rank="4" />
+                <subcommittee subcomcode="AG16" rank="3" />
+                <subcommittee subcomcode="AG22" rank="3" />
+                <subcommittee subcomcode="AS03" rank="5" />
+                <subcommittee subcomcode="AS29" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="HM07" rank="3" />
+                <subcommittee subcomcode="HM11" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AL04</statedistrict>
+            <member-info>
+                <namelist>Aderholt, Robert</namelist>
+                <bioguideID>A000055</bioguideID>
+                <lastname>Aderholt</lastname>
+                <firstname>Robert</firstname>
+                <middlename>B.</middlename>
+                <sort-name>ADERHOLT,ROBERT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Robert B. Aderholt</official-name>
+                <formal-name>Mr. Aderholt</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AL">
+                    <state-fullname>Alabama</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Haleyville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>235</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0104</office-zip-suffix>
+                <phone>(202) 225-4876</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="3" />
+                <subcommittee subcomcode="AP01" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AP02" rank="6" />
+                <subcommittee subcomcode="AP19" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AL05</statedistrict>
+            <member-info>
+                <namelist>Brooks, Mo</namelist>
+                <bioguideID>B001274</bioguideID>
+                <lastname>Brooks</lastname>
+                <firstname>Mo</firstname>
+                <middlename/>
+                <sort-name>BROOKS,MO</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mo Brooks</official-name>
+                <formal-name>Mr. Brooks of Alabama</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AL">
+                    <state-fullname>Alabama</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Huntsville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2400</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0105</office-zip-suffix>
+                <phone>(202) 225-4801</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="17" />
+                <committee comcode="FA00" rank="12" />
+                <committee comcode="SY00" rank="4" />
+                <subcommittee subcomcode="AS25" rank="14" />
+                <subcommittee subcomcode="AS29" rank="5" />
+                <subcommittee subcomcode="FA05" rank="5" />
+                <subcommittee subcomcode="FA07" rank="5" />
+                <subcommittee subcomcode="SY16" rank="4" leadership="Vice Chair" />
+                <subcommittee subcomcode="SY18" rank="4" />
+                <subcommittee subcomcode="SY20" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AL06</statedistrict>
+            <member-info>
+                <namelist>Palmer, Gary</namelist>
+                <bioguideID>P000609</bioguideID>
+                <lastname>Palmer</lastname>
+                <firstname>Gary</firstname>
+                <middlename>J.</middlename>
+                <sort-name>PALMER,GARY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Gary J. Palmer</official-name>
+                <formal-name>Mr. Palmer</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AL">
+                    <state-fullname>Alabama</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Hoover</townname>
+                <office-building>CHOB</office-building>
+                <office-room>330</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0106</office-zip-suffix>
+                <phone>(202) 225-4921</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="11" />
+                <committee comcode="GO00" rank="22" />
+                <committee comcode="SY00" rank="13" />
+                <subcommittee subcomcode="GO28" rank="4" />
+                <subcommittee subcomcode="GO29" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="SY18" rank="7" />
+                <subcommittee subcomcode="SY21" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AL07</statedistrict>
+            <member-info>
+                <namelist>Sewell, Terri</namelist>
+                <bioguideID>S001185</bioguideID>
+                <lastname>Sewell</lastname>
+                <firstname>Terri</firstname>
+                <middlename>A.</middlename>
+                <sort-name>SEWELL,TERRI</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Terri A. Sewell</official-name>
+                <formal-name>Ms. Sewell of Alabama</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="AL">
+                    <state-fullname>Alabama</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Birmingham</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2201</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0107</office-zip-suffix>
+                <phone>(202) 225-2665</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IG00" rank="3" />
+                <committee comcode="WM00" rank="14" />
+                <subcommittee subcomcode="IG02" rank="2" />
+                <subcommittee subcomcode="IG04" rank="1" />
+                <subcommittee subcomcode="WM02" rank="6" />
+                <subcommittee subcomcode="WM03" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AR01</statedistrict>
+            <member-info>
+                <namelist>Crawford, Eric</namelist>
+                <bioguideID>C001087</bioguideID>
+                <lastname>Crawford</lastname>
+                <firstname>Eric</firstname>
+                <middlename>A. "Rick"</middlename>
+                <sort-name>CRAWFORD,ERIC</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Eric A. "Rick" Crawford</official-name>
+                <formal-name>Mr. Crawford</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AR">
+                    <state-fullname>Arkansas</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Jonesboro</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2422</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0401</office-zip-suffix>
+                <phone>(202) 225-4076</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="9" />
+                <committee comcode="IG00" rank="10" />
+                <committee comcode="PW00" rank="7" />
+                <subcommittee subcomcode="AG03" rank="3" />
+                <subcommittee subcomcode="AG16" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="IG03" rank="4" />
+                <subcommittee subcomcode="IG04" rank="4" />
+                <subcommittee subcomcode="PW02" rank="2" />
+                <subcommittee subcomcode="PW12" rank="6" />
+                <subcommittee subcomcode="PW13" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AR02</statedistrict>
+            <member-info>
+                <namelist>Hill, J.</namelist>
+                <bioguideID>H001072</bioguideID>
+                <lastname>Hill</lastname>
+                <firstname>J.</firstname>
+                <middlename>French</middlename>
+                <sort-name>HILL,J.</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>J. French Hill</official-name>
+                <formal-name>Mr. Hill</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AR">
+                    <state-fullname>Arkansas</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Little Rock</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1229</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0402</office-zip-suffix>
+                <phone>(202) 225-2506</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="23" />
+                <subcommittee subcomcode="BA01" rank="9" />
+                <subcommittee subcomcode="BA16" rank="10" />
+                <subcommittee subcomcode="BA20" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AR03</statedistrict>
+            <member-info>
+                <namelist>Womack, Steve</namelist>
+                <bioguideID>W000809</bioguideID>
+                <lastname>Womack</lastname>
+                <firstname>Steve</firstname>
+                <middlename/>
+                <sort-name>WOMACK,STEVE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steve Womack</official-name>
+                <formal-name>Mr. Womack</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AR">
+                    <state-fullname>Arkansas</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Rogers</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2412</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0403</office-zip-suffix>
+                <phone>(202) 225-4301</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="14" />
+                <committee comcode="BU00" rank="8" />
+                <subcommittee subcomcode="AP02" rank="5" />
+                <subcommittee subcomcode="AP07" rank="3" leadership="Vice Chair" />
+                <subcommittee subcomcode="AP18" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AR04</statedistrict>
+            <member-info>
+                <namelist>Westerman, Bruce</namelist>
+                <bioguideID>W000821</bioguideID>
+                <lastname>Westerman</lastname>
+                <firstname>Bruce</firstname>
+                <middlename/>
+                <sort-name>WESTERMAN,BRUCE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bruce Westerman</official-name>
+                <formal-name>Mr. Westerman</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AR">
+                    <state-fullname>Arkansas</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Hot Springs</townname>
+                <office-building>CHOB</office-building>
+                <office-room>130</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0404</office-zip-suffix>
+                <phone>(202) 225-3772</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="12" />
+                <committee comcode="II00" rank="15" />
+                <committee comcode="PW00" rank="28" />
+                <subcommittee subcomcode="II06" rank="9" />
+                <subcommittee subcomcode="II10" rank="7" />
+                <subcommittee subcomcode="PW05" rank="19" />
+                <subcommittee subcomcode="PW12" rank="23" />
+                <subcommittee subcomcode="PW14" rank="14" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AQ00</statedistrict>
+            <member-info>
+                <namelist>Radewagen, Aumua Amata</namelist>
+                <bioguideID>R000600</bioguideID>
+                <lastname>Radewagen</lastname>
+                <firstname>Aumua Amata</firstname>
+                <middlename>Coleman</middlename>
+                <sort-name>RADEWAGEN,AUMUAAMATA</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Aumua Amata Coleman Radewagen</official-name>
+                <formal-name>Mrs. Radewagen</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AS">
+                    <state-fullname>American Samoa</state-fullname>
+                </state>
+                <district>Delegate</district>
+                <townname>Pago Pago</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1339</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>5200</office-zip-suffix>
+                <phone>(202) 225-8577</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="18" />
+                <committee comcode="SM00" rank="5" />
+                <committee comcode="VR00" rank="5" />
+                <subcommittee subcomcode="II15" rank="3" />
+                <subcommittee subcomcode="II24" rank="5" />
+                <subcommittee subcomcode="SM25" rank="4" />
+                <subcommittee subcomcode="SM26" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="VR03" rank="3" />
+                <subcommittee subcomcode="VR09" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ01</statedistrict>
+            <member-info>
+                <namelist>O'Halleran, Tom</namelist>
+                <bioguideID>O000171</bioguideID>
+                <lastname>O'Halleran</lastname>
+                <firstname>Tom</firstname>
+                <middlename/>
+                <sort-name>OHALLERAN,TOM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Tom O'Halleran</official-name>
+                <formal-name>Mr. O'Halleran</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Sedona</townname>
+                <office-building>CHOB</office-building>
+                <office-room>126</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0301</office-zip-suffix>
+                <phone>(202) 225-3361</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="17" />
+                <committee comcode="AS00" rank="26" />
+                <subcommittee subcomcode="AG15" rank="5" />
+                <subcommittee subcomcode="AG16" rank="9" />
+                <subcommittee subcomcode="AG22" rank="5" />
+                <subcommittee subcomcode="AS06" rank="2" />
+                <subcommittee subcomcode="AS25" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ02</statedistrict>
+            <member-info>
+                <namelist>McSally, Martha</namelist>
+                <bioguideID>M001197</bioguideID>
+                <lastname>McSally</lastname>
+                <firstname>Martha</firstname>
+                <middlename/>
+                <sort-name>MCSALLY,MARTHA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Martha McSally</official-name>
+                <formal-name>Ms. McSally</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Tucson</townname>
+                <office-building>CHOB</office-building>
+                <office-room>510</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0302</office-zip-suffix>
+                <phone>(202) 225-2542</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="24" />
+                <committee comcode="HM00" rank="11" />
+                <subcommittee subcomcode="AS02" rank="6" />
+                <subcommittee subcomcode="AS03" rank="8" leadership="Vice Chair" />
+                <subcommittee subcomcode="AS25" rank="5" />
+                <subcommittee subcomcode="HM11" rank="1" leadership="Chairwoman" />
+                <subcommittee subcomcode="HM12" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ03</statedistrict>
+            <member-info>
+                <namelist>Grijalva, Raúl</namelist>
+                <bioguideID>G000551</bioguideID>
+                <lastname>Grijalva</lastname>
+                <firstname>Raúl</firstname>
+                <middlename>M.</middlename>
+                <sort-name>GRIJALVA,RAUL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Raúl M. Grijalva</official-name>
+                <formal-name>Mr. Grijalva</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Tucson</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1511</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0303</office-zip-suffix>
+                <phone>(202) 225-2435</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="3" />
+                <committee comcode="II00" rank="1" />
+                <subcommittee subcomcode="ED10" rank="2" />
+                <subcommittee subcomcode="ED14" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ04</statedistrict>
+            <member-info>
+                <namelist>Gosar, Paul</namelist>
+                <bioguideID>G000565</bioguideID>
+                <lastname>Gosar</lastname>
+                <firstname>Paul</firstname>
+                <middlename>A.</middlename>
+                <sort-name>GOSAR,PAUL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Paul A. Gosar</official-name>
+                <formal-name>Mr. Gosar</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Prescott</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2057</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0304</office-zip-suffix>
+                <phone>(202) 225-2315</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="7" />
+                <committee comcode="II00" rank="9" />
+                <subcommittee subcomcode="GO06" rank="5" />
+                <subcommittee subcomcode="GO28" rank="2" leadership="Vice Chair" />
+                <subcommittee subcomcode="II06" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="II13" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ05</statedistrict>
+            <member-info>
+                <namelist>Biggs, Andy</namelist>
+                <bioguideID>B001302</bioguideID>
+                <lastname>Biggs</lastname>
+                <firstname>Andy</firstname>
+                <middlename/>
+                <sort-name>BIGGS,ANDY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Andy Biggs</official-name>
+                <formal-name>Mr. Biggs</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Gilbert</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1626</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0305</office-zip-suffix>
+                <phone>(202) 225-2635</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="JU00" rank="23" />
+                <committee comcode="SY00" rank="19" />
+                <subcommittee subcomcode="JU01" rank="8" />
+                <subcommittee subcomcode="JU03" rank="14" />
+                <subcommittee subcomcode="SY16" rank="12" />
+                <subcommittee subcomcode="SY18" rank="1" leadership="Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ06</statedistrict>
+            <member-info>
+                <namelist>Schweikert, David</namelist>
+                <bioguideID>S001183</bioguideID>
+                <lastname>Schweikert</lastname>
+                <firstname>David</firstname>
+                <middlename/>
+                <sort-name>SCHWEIKERT,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David Schweikert</official-name>
+                <formal-name>Mr. Schweikert</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Fountain Hills</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2059</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0306</office-zip-suffix>
+                <phone>(202) 225-2190</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="EC00" rank="3" />
+                <committee comcode="WM00" rank="21" />
+                <subcommittee subcomcode="WM01" rank="3" />
+                <subcommittee subcomcode="WM06" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ07</statedistrict>
+            <member-info>
+                <namelist>Gallego, Ruben</namelist>
+                <bioguideID>G000574</bioguideID>
+                <lastname>Gallego</lastname>
+                <firstname>Ruben</firstname>
+                <middlename/>
+                <sort-name>GALLEGO,RUBEN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ruben Gallego</official-name>
+                <formal-name>Mr. Gallego</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Phoenix</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1218</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0307</office-zip-suffix>
+                <phone>(202) 225-4065</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="16" />
+                <committee comcode="II00" rank="11" />
+                <subcommittee subcomcode="AS02" rank="4" />
+                <subcommittee subcomcode="AS25" rank="5" />
+                <subcommittee subcomcode="II10" rank="5" />
+                <subcommittee subcomcode="II15" rank="2" />
+                <subcommittee subcomcode="II24" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ08</statedistrict>
+            <member-info>
+                <namelist>Franks, Trent</namelist>
+                <bioguideID>F000448</bioguideID>
+                <lastname>Franks</lastname>
+                <firstname>Trent</firstname>
+                <middlename/>
+                <sort-name>FRANKS,TRENT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Trent Franks</official-name>
+                <formal-name>Mr. Franks of Arizona</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Peoria</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2435</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0308</office-zip-suffix>
+                <phone>(202) 225-4576</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="8" />
+                <committee comcode="JU00" rank="7" />
+                <subcommittee subcomcode="AS26" rank="8" />
+                <subcommittee subcomcode="AS29" rank="2" leadership="Vice Chair" />
+                <subcommittee subcomcode="JU03" rank="5" />
+                <subcommittee subcomcode="JU10" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>AZ09</statedistrict>
+            <member-info>
+                <namelist>Sinema, Kyrsten</namelist>
+                <bioguideID>S001191</bioguideID>
+                <lastname>Sinema</lastname>
+                <firstname>Kyrsten</firstname>
+                <middlename/>
+                <sort-name>SINEMA,KYRSTEN</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kyrsten Sinema</official-name>
+                <formal-name>Ms. Sinema</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="AZ">
+                    <state-fullname>Arizona</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Phoenix</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1725</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0309</office-zip-suffix>
+                <phone>(202) 225-9888</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="19" />
+                <subcommittee subcomcode="BA01" rank="7" />
+                <subcommittee subcomcode="BA16" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA01</statedistrict>
+            <member-info>
+                <namelist>LaMalfa, Doug</namelist>
+                <bioguideID>L000578</bioguideID>
+                <lastname>LaMalfa</lastname>
+                <firstname>Doug</firstname>
+                <middlename/>
+                <sort-name>LAMALFA,DOUG</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Doug LaMalfa</official-name>
+                <formal-name>Mr. LaMalfa</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Oroville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>322</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0501</office-zip-suffix>
+                <phone>(202) 225-3076</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="13" />
+                <committee comcode="II00" rank="12" />
+                <committee comcode="PW00" rank="27" />
+                <subcommittee subcomcode="AG15" rank="4" />
+                <subcommittee subcomcode="AG22" rank="4" />
+                <subcommittee subcomcode="II13" rank="5" />
+                <subcommittee subcomcode="II24" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="PW02" rank="15" />
+                <subcommittee subcomcode="PW05" rank="18" />
+                <subcommittee subcomcode="PW12" rank="22" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA02</statedistrict>
+            <member-info>
+                <namelist>Huffman, Jared</namelist>
+                <bioguideID>H001068</bioguideID>
+                <lastname>Huffman</lastname>
+                <firstname>Jared</firstname>
+                <middlename/>
+                <sort-name>HUFFMAN,JARED</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jared Huffman</official-name>
+                <formal-name>Mr. Huffman</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>San Rafael</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1406</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0502</office-zip-suffix>
+                <phone>(202) 225-5161</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="7" />
+                <committee comcode="PW00" rank="21" />
+                <subcommittee subcomcode="II06" rank="5" />
+                <subcommittee subcomcode="II13" rank="1" />
+                <subcommittee subcomcode="II15" rank="3" />
+                <subcommittee subcomcode="PW02" rank="4" />
+                <subcommittee subcomcode="PW07" rank="4" />
+                <subcommittee subcomcode="PW12" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA03</statedistrict>
+            <member-info>
+                <namelist>Garamendi, John</namelist>
+                <bioguideID>G000559</bioguideID>
+                <lastname>Garamendi</lastname>
+                <firstname>John</firstname>
+                <middlename/>
+                <sort-name>GARAMENDI,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John Garamendi</official-name>
+                <formal-name>Mr. Garamendi</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Walnut Grove</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2438</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0503</office-zip-suffix>
+                <phone>(202) 225-1880</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="10" />
+                <committee comcode="PW00" rank="12" />
+                <subcommittee subcomcode="AS28" rank="5" />
+                <subcommittee subcomcode="AS29" rank="4" />
+                <subcommittee subcomcode="PW02" rank="7" />
+                <subcommittee subcomcode="PW07" rank="1" />
+                <subcommittee subcomcode="PW14" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA04</statedistrict>
+            <member-info>
+                <namelist>McClintock, Tom</namelist>
+                <bioguideID>M001177</bioguideID>
+                <lastname>McClintock</lastname>
+                <firstname>Tom</firstname>
+                <middlename/>
+                <sort-name>MCCLINTOCK,TOM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tom McClintock</official-name>
+                <formal-name>Mr. McClintock</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Roseville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2312</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0504</office-zip-suffix>
+                <phone>(202) 225-2511</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="4" />
+                <committee comcode="II00" rank="6" />
+                <subcommittee subcomcode="II10" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="II13" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA05</statedistrict>
+            <member-info>
+                <namelist>Thompson, Mike</namelist>
+                <bioguideID>T000460</bioguideID>
+                <lastname>Thompson</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>THOMPSON,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mike Thompson</official-name>
+                <formal-name>Mr. Thompson of California</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>St. Helena</townname>
+                <office-building>CHOB</office-building>
+                <office-room>231</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0505</office-zip-suffix>
+                <phone>(202) 225-3311</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="5" />
+                <subcommittee subcomcode="WM02" rank="2" />
+                <subcommittee subcomcode="WM05" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA06</statedistrict>
+            <member-info>
+                <namelist>Matsui, Doris</namelist>
+                <bioguideID>M001163</bioguideID>
+                <lastname>Matsui</lastname>
+                <firstname>Doris</firstname>
+                <middlename>O.</middlename>
+                <sort-name>MATSUI,DORIS</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Doris O. Matsui</official-name>
+                <formal-name>Ms. Matsui</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Sacramento</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2311</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0506</office-zip-suffix>
+                <phone>(202) 225-7163</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="10" />
+                <subcommittee subcomcode="IF14" rank="5" />
+                <subcommittee subcomcode="IF16" rank="11" />
+                <subcommittee subcomcode="IF17" rank="6" />
+                <subcommittee subcomcode="IF18" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA07</statedistrict>
+            <member-info>
+                <namelist>Bera, Ami</namelist>
+                <bioguideID>B001287</bioguideID>
+                <lastname>Bera</lastname>
+                <firstname>Ami</firstname>
+                <middlename/>
+                <sort-name>BERA,AMI</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ami Bera</official-name>
+                <formal-name>Mr. Bera</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Elk Grove</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1431</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0507</office-zip-suffix>
+                <phone>(202) 225-5716</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="10" />
+                <committee comcode="SY00" rank="5" />
+                <subcommittee subcomcode="FA05" rank="2" />
+                <subcommittee subcomcode="FA16" rank="2" />
+                <subcommittee subcomcode="SY15" rank="5" />
+                <subcommittee subcomcode="SY16" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA08</statedistrict>
+            <member-info>
+                <namelist>Cook, Paul</namelist>
+                <bioguideID>C001094</bioguideID>
+                <lastname>Cook</lastname>
+                <firstname>Paul</firstname>
+                <middlename/>
+                <sort-name>COOK,PAUL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Paul Cook</official-name>
+                <formal-name>Mr. Cook</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Yucca Valley</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1222</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0508</office-zip-suffix>
+                <phone>(202) 225-5861</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="18" />
+                <committee comcode="FA00" rank="13" />
+                <committee comcode="II00" rank="14" />
+                <subcommittee subcomcode="AS25" rank="3" leadership="Vice Chair" />
+                <subcommittee subcomcode="AS28" rank="8" />
+                <subcommittee subcomcode="FA13" rank="6" />
+                <subcommittee subcomcode="FA18" rank="4" />
+                <subcommittee subcomcode="II06" rank="8" />
+                <subcommittee subcomcode="II24" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA09</statedistrict>
+            <member-info>
+                <namelist>McNerney, Jerry</namelist>
+                <bioguideID>M001166</bioguideID>
+                <lastname>McNerney</lastname>
+                <firstname>Jerry</firstname>
+                <middlename/>
+                <sort-name>MCNERNEY,JERRY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jerry McNerney</official-name>
+                <formal-name>Mr. McNerney</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Stockton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2265</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0509</office-zip-suffix>
+                <phone>(202) 225-1947</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="13" />
+                <committee comcode="SY00" rank="10" />
+                <subcommittee subcomcode="IF03" rank="2" />
+                <subcommittee subcomcode="IF16" rank="12" />
+                <subcommittee subcomcode="IF18" rank="6" />
+                <subcommittee subcomcode="SY20" rank="5" />
+                <subcommittee subcomcode="SY21" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA10</statedistrict>
+            <member-info>
+                <namelist>Denham, Jeff</namelist>
+                <bioguideID>D000612</bioguideID>
+                <lastname>Denham</lastname>
+                <firstname>Jeff</firstname>
+                <middlename/>
+                <sort-name>DENHAM,JEFF</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jeff Denham</official-name>
+                <formal-name>Mr. Denham</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Turlock</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1730</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0510</office-zip-suffix>
+                <phone>(202) 225-4540</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="12" />
+                <committee comcode="II00" rank="13" />
+                <committee comcode="PW00" rank="12" />
+                <subcommittee subcomcode="AG14" rank="3" />
+                <subcommittee subcomcode="AG15" rank="3" />
+                <subcommittee subcomcode="II13" rank="6" />
+                <subcommittee subcomcode="II24" rank="3" />
+                <subcommittee subcomcode="PW05" rank="9" />
+                <subcommittee subcomcode="PW12" rank="10" />
+                <subcommittee subcomcode="PW14" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA11</statedistrict>
+            <member-info>
+                <namelist>DeSaulnier, Mark</namelist>
+                <bioguideID>D000623</bioguideID>
+                <lastname>DeSaulnier</lastname>
+                <firstname>Mark</firstname>
+                <middlename/>
+                <sort-name>DESAULNIER,MARK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mark DeSaulnier</official-name>
+                <formal-name>Mr. DeSaulnier</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Concord</townname>
+                <office-building>CHOB</office-building>
+                <office-room>115</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0511</office-zip-suffix>
+                <phone>(202) 225-2095</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="12" />
+                <committee comcode="GO00" rank="17" />
+                <committee comcode="PW00" rank="27" />
+                <subcommittee subcomcode="ED10" rank="4" />
+                <subcommittee subcomcode="ED13" rank="4" />
+                <subcommittee subcomcode="GO06" rank="4" />
+                <subcommittee subcomcode="GO29" rank="2" />
+                <subcommittee subcomcode="PW12" rank="13" />
+                <subcommittee subcomcode="PW14" rank="13" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA12</statedistrict>
+            <member-info>
+                <namelist>Pelosi, Nancy</namelist>
+                <bioguideID>P000197</bioguideID>
+                <lastname>Pelosi</lastname>
+                <firstname>Nancy</firstname>
+                <middlename/>
+                <sort-name>PELOSI,NANCY</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Nancy Pelosi</official-name>
+                <formal-name>Ms. Pelosi</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>San Francisco</townname>
+                <office-building>CHOB</office-building>
+                <office-room>233</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0512</office-zip-suffix>
+                <phone>(202) 225-4965</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA13</statedistrict>
+            <member-info>
+                <namelist>Lee, Barbara</namelist>
+                <bioguideID>L000551</bioguideID>
+                <lastname>Lee</lastname>
+                <firstname>Barbara</firstname>
+                <middlename/>
+                <sort-name>LEE,BARBARA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Barbara Lee</official-name>
+                <formal-name>Ms. Lee</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>Oakland</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2267</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0513</office-zip-suffix>
+                <phone>(202) 225-2661</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="9" />
+                <committee comcode="BU00" rank="2" />
+                <subcommittee subcomcode="AP04" rank="2" />
+                <subcommittee subcomcode="AP07" rank="3" />
+                <subcommittee subcomcode="AP18" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA14</statedistrict>
+            <member-info>
+                <namelist>Speier, Jackie</namelist>
+                <bioguideID>S001175</bioguideID>
+                <lastname>Speier</lastname>
+                <firstname>Jackie</firstname>
+                <middlename/>
+                <sort-name>SPEIER,JACKIE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jackie Speier</official-name>
+                <formal-name>Ms. Speier</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Hillsborough</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2465</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0514</office-zip-suffix>
+                <phone>(202) 225-3531</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="11" />
+                <committee comcode="IG00" rank="5" />
+                <subcommittee subcomcode="AS02" rank="1" />
+                <subcommittee subcomcode="AS26" rank="4" />
+                <subcommittee subcomcode="IG02" rank="3" />
+                <subcommittee subcomcode="IG03" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA15</statedistrict>
+            <member-info>
+                <namelist>Swalwell, Eric</namelist>
+                <bioguideID>S001193</bioguideID>
+                <lastname>Swalwell</lastname>
+                <firstname>Eric</firstname>
+                <middlename/>
+                <sort-name>SWALWELL,ERIC</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Eric Swalwell</official-name>
+                <formal-name>Mr. Swalwell of California</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>15th</district>
+                <townname>Pleasanton</townname>
+                <office-building>CHOB</office-building>
+                <office-room>129</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0515</office-zip-suffix>
+                <phone>(202) 225-5065</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IG00" rank="7" />
+                <committee comcode="JU00" rank="13" />
+                <subcommittee subcomcode="IG01" rank="1" />
+                <subcommittee subcomcode="IG03" rank="4" />
+                <subcommittee subcomcode="JU03" rank="8" />
+                <subcommittee subcomcode="JU05" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA16</statedistrict>
+            <member-info>
+                <namelist>Costa, Jim</namelist>
+                <bioguideID>C001059</bioguideID>
+                <lastname>Costa</lastname>
+                <firstname>Jim</firstname>
+                <middlename/>
+                <sort-name>COSTA,JIM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jim Costa</official-name>
+                <formal-name>Mr. Costa</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>16th</district>
+                <townname>Fresno</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2081</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0516</office-zip-suffix>
+                <phone>(202) 225-3341</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="3" />
+                <committee comcode="II00" rank="4" />
+                <subcommittee subcomcode="AG14" rank="4" />
+                <subcommittee subcomcode="AG29" rank="1" />
+                <subcommittee subcomcode="II06" rank="3" />
+                <subcommittee subcomcode="II13" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA17</statedistrict>
+            <member-info>
+                <namelist>Khanna, Ro</namelist>
+                <bioguideID>K000389</bioguideID>
+                <lastname>Khanna</lastname>
+                <firstname>Ro</firstname>
+                <middlename/>
+                <sort-name>KHANNA,RO</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Ro Khanna</official-name>
+                <formal-name>Mr. Khanna</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>17th</district>
+                <townname>Fremont</townname>
+                <office-building>CHOB</office-building>
+                <office-room>513</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0517</office-zip-suffix>
+                <phone>(202) 225-2631</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="25" />
+                <committee comcode="BU00" rank="10" />
+                <subcommittee subcomcode="AS03" rank="9" />
+                <subcommittee subcomcode="AS29" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA18</statedistrict>
+            <member-info>
+                <namelist>Eshoo, Anna</namelist>
+                <bioguideID>E000215</bioguideID>
+                <lastname>Eshoo</lastname>
+                <firstname>Anna</firstname>
+                <middlename>G.</middlename>
+                <sort-name>ESHOO,ANNA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Anna G. Eshoo</official-name>
+                <formal-name>Ms. Eshoo</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>18th</district>
+                <townname>Atherton</townname>
+                <office-building>CHOB</office-building>
+                <office-room>241</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0518</office-zip-suffix>
+                <phone>(202) 225-8104</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="3" />
+                <subcommittee subcomcode="IF14" rank="12" />
+                <subcommittee subcomcode="IF16" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA19</statedistrict>
+            <member-info>
+                <namelist>Lofgren, Zoe</namelist>
+                <bioguideID>L000397</bioguideID>
+                <lastname>Lofgren</lastname>
+                <firstname>Zoe</firstname>
+                <middlename/>
+                <sort-name>LOFGREN,ZOE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Zoe Lofgren</official-name>
+                <formal-name>Ms. Lofgren</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>19th</district>
+                <townname>San José</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1401</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0519</office-zip-suffix>
+                <phone>(202) 225-3072</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HA00" rank="2" />
+                <committee comcode="JL00" rank="5" />
+                <committee comcode="JU00" rank="3" />
+                <committee comcode="SY00" rank="2" />
+                <subcommittee subcomcode="JU01" rank="1" />
+                <subcommittee subcomcode="JU03" rank="10" />
+                <subcommittee subcomcode="SY16" rank="2" />
+                <subcommittee subcomcode="SY20" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA20</statedistrict>
+            <member-info>
+                <namelist>Panetta, Jimmy</namelist>
+                <bioguideID>P000613</bioguideID>
+                <lastname>Panetta</lastname>
+                <firstname>Jimmy</firstname>
+                <middlename/>
+                <sort-name>PANETTA,JIMMY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Jimmy Panetta</official-name>
+                <formal-name>Mr. Panetta</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>20th</district>
+                <townname>Carmel Valley</townname>
+                <office-building>CHOB</office-building>
+                <office-room>228</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0520</office-zip-suffix>
+                <phone>(202) 225-2861</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="18" />
+                <committee comcode="II00" rank="15" />
+                <subcommittee subcomcode="AG03" rank="7" />
+                <subcommittee subcomcode="AG14" rank="3" />
+                <subcommittee subcomcode="II10" rank="6" />
+                <subcommittee subcomcode="II13" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA21</statedistrict>
+            <member-info>
+                <namelist>Valadao, David</namelist>
+                <bioguideID>V000129</bioguideID>
+                <lastname>Valadao</lastname>
+                <firstname>David</firstname>
+                <middlename>G.</middlename>
+                <sort-name>VALADAO,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David G. Valadao</official-name>
+                <formal-name>Mr. Valadao</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>21st</district>
+                <townname>Hanford</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1728</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0521</office-zip-suffix>
+                <phone>(202) 225-4695</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="20" />
+                <subcommittee subcomcode="AP01" rank="4" leadership="Vice Chair" />
+                <subcommittee subcomcode="AP18" rank="4" />
+                <subcommittee subcomcode="AP20" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA22</statedistrict>
+            <member-info>
+                <namelist>Nunes, Devin</namelist>
+                <bioguideID>N000181</bioguideID>
+                <lastname>Nunes</lastname>
+                <firstname>Devin</firstname>
+                <middlename/>
+                <sort-name>NUNES,DEVIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Devin Nunes</official-name>
+                <formal-name>Mr. Nunes</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>22nd</district>
+                <townname>Tulare</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1013</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0522</office-zip-suffix>
+                <phone>(202) 225-2523</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IG00" rank="1" leadership="Chairman" />
+                <committee comcode="IT00" rank="3" />
+                <committee comcode="WM00" rank="3" />
+                <subcommittee subcomcode="WM02" rank="3" />
+                <subcommittee subcomcode="WM04" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA23</statedistrict>
+            <member-info>
+                <namelist>McCarthy, Kevin</namelist>
+                <bioguideID>M001165</bioguideID>
+                <lastname>McCarthy</lastname>
+                <firstname>Kevin</firstname>
+                <middlename/>
+                <sort-name>MCCARTHY,KEVIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kevin McCarthy</official-name>
+                <formal-name>Mr. McCarthy</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>23rd</district>
+                <townname>Bakersfield</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2421</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0523</office-zip-suffix>
+                <phone>(202) 225-2915</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA24</statedistrict>
+            <member-info>
+                <namelist>Carbajal, Salud</namelist>
+                <bioguideID>C001112</bioguideID>
+                <lastname>Carbajal</lastname>
+                <firstname>Salud</firstname>
+                <middlename>O.</middlename>
+                <sort-name>CARBAJAL,SALUD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Salud O. Carbajal</official-name>
+                <formal-name>Mr. Carbajal</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>24th</district>
+                <townname>Santa Barbara</townname>
+                <office-building>CHOB</office-building>
+                <office-room>212</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0524</office-zip-suffix>
+                <phone>(202) 225-3601</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="22" />
+                <committee comcode="BU00" rank="12" />
+                <subcommittee subcomcode="AS03" rank="6" />
+                <subcommittee subcomcode="AS25" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA25</statedistrict>
+            <member-info>
+                <namelist>Knight, Stephen</namelist>
+                <bioguideID>K000387</bioguideID>
+                <lastname>Knight</lastname>
+                <firstname>Stephen</firstname>
+                <middlename/>
+                <sort-name>KNIGHT,STEPHEN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Stephen Knight</official-name>
+                <formal-name>Mr. Knight</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>25th</district>
+                <townname>Palmdale</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1023</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0525</office-zip-suffix>
+                <phone>(202) 225-1956</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="25" />
+                <committee comcode="SM00" rank="6" />
+                <committee comcode="SY00" rank="10" />
+                <subcommittee subcomcode="AS25" rank="6" />
+                <subcommittee subcomcode="AS28" rank="10" />
+                <subcommittee subcomcode="SM23" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="SM27" rank="2" />
+                <subcommittee subcomcode="SY15" rank="4" />
+                <subcommittee subcomcode="SY16" rank="7" />
+                <subcommittee subcomcode="SY20" rank="8" leadership="Vice Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA26</statedistrict>
+            <member-info>
+                <namelist>Brownley, Julia</namelist>
+                <bioguideID>B001285</bioguideID>
+                <lastname>Brownley</lastname>
+                <firstname>Julia</firstname>
+                <middlename/>
+                <sort-name>BROWNLEY,JULIA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Julia Brownley</official-name>
+                <formal-name>Ms. Brownley of California</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>26th</district>
+                <townname>Westlake Village</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1019</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0526</office-zip-suffix>
+                <phone>(202) 225-5811</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="PW00" rank="22" />
+                <committee comcode="VR00" rank="3" />
+                <subcommittee subcomcode="PW02" rank="12" />
+                <subcommittee subcomcode="PW05" rank="9" />
+                <subcommittee subcomcode="PW12" rank="10" />
+                <subcommittee subcomcode="VR03" rank="1" />
+                <subcommittee subcomcode="VR09" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA27</statedistrict>
+            <member-info>
+                <namelist>Chu, Judy</namelist>
+                <bioguideID>C001080</bioguideID>
+                <lastname>Chu</lastname>
+                <firstname>Judy</firstname>
+                <middlename/>
+                <sort-name>CHU,JUDY</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Judy Chu</official-name>
+                <formal-name>Ms. Judy Chu of California</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>27th</district>
+                <townname>Monterey Park</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2423</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0527</office-zip-suffix>
+                <phone>(202) 225-5464</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="SM00" rank="6" />
+                <committee comcode="WM00" rank="16" />
+                <subcommittee subcomcode="SM27" rank="2" />
+                <subcommittee subcomcode="WM02" rank="7" />
+                <subcommittee subcomcode="WM03" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA28</statedistrict>
+            <member-info>
+                <namelist>Schiff, Adam</namelist>
+                <bioguideID>S001150</bioguideID>
+                <lastname>Schiff</lastname>
+                <firstname>Adam</firstname>
+                <middlename>B.</middlename>
+                <sort-name>SCHIFF,ADAM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Adam B. Schiff</official-name>
+                <formal-name>Mr. Schiff</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>28th</district>
+                <townname>Burbank</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2372</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0528</office-zip-suffix>
+                <phone>(202) 225-4176</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IG00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA29</statedistrict>
+            <member-info>
+                <namelist>Cárdenas, Tony</namelist>
+                <bioguideID>C001097</bioguideID>
+                <lastname>Cárdenas</lastname>
+                <firstname>Tony</firstname>
+                <middlename/>
+                <sort-name>CARDENAS,TONY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tony Cárdenas</official-name>
+                <formal-name>Mr. Cárdenas</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>29th</district>
+                <townname>Pacoima</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1510</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0529</office-zip-suffix>
+                <phone>(202) 225-6131</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="21" />
+                <subcommittee subcomcode="IF14" rank="11" />
+                <subcommittee subcomcode="IF17" rank="4" />
+                <subcommittee subcomcode="IF18" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA30</statedistrict>
+            <member-info>
+                <namelist>Sherman, Brad</namelist>
+                <bioguideID>S000344</bioguideID>
+                <lastname>Sherman</lastname>
+                <firstname>Brad</firstname>
+                <middlename/>
+                <sort-name>SHERMAN,BRAD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Brad Sherman</official-name>
+                <formal-name>Mr. Sherman</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>30th</district>
+                <townname>Sherman Oaks</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2181</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0530</office-zip-suffix>
+                <phone>(202) 225-5911</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="4" />
+                <committee comcode="FA00" rank="2" />
+                <subcommittee subcomcode="BA04" rank="5" />
+                <subcommittee subcomcode="BA16" rank="2" />
+                <subcommittee subcomcode="BA20" rank="4" />
+                <subcommittee subcomcode="FA05" rank="1" />
+                <subcommittee subcomcode="FA14" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA31</statedistrict>
+            <member-info>
+                <namelist>Aguilar, Pete</namelist>
+                <bioguideID>A000371</bioguideID>
+                <lastname>Aguilar</lastname>
+                <firstname>Pete</firstname>
+                <middlename/>
+                <sort-name>AGUILAR,PETE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Pete Aguilar</official-name>
+                <formal-name>Mr. Aguilar</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>31st</district>
+                <townname>Redlands</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1223</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0531</office-zip-suffix>
+                <phone>(202) 225-3201</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="22" />
+                <subcommittee subcomcode="AP10" rank="4" />
+                <subcommittee subcomcode="AP20" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA32</statedistrict>
+            <member-info>
+                <namelist>Napolitano, Grace</namelist>
+                <bioguideID>N000179</bioguideID>
+                <lastname>Napolitano</lastname>
+                <firstname>Grace</firstname>
+                <middlename>F.</middlename>
+                <sort-name>NAPOLITANO,GRACE</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Grace F. Napolitano</official-name>
+                <formal-name>Mrs. Napolitano</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>32nd</district>
+                <townname>Norwalk</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1610</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0532</office-zip-suffix>
+                <phone>(202) 225-5256</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="2" />
+                <committee comcode="PW00" rank="8" />
+                <subcommittee subcomcode="II13" rank="2" />
+                <subcommittee subcomcode="PW02" rank="1" />
+                <subcommittee subcomcode="PW05" rank="13" />
+                <subcommittee subcomcode="PW12" rank="16" />
+                <subcommittee subcomcode="PW13" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA33</statedistrict>
+            <member-info>
+                <namelist>Lieu, Ted</namelist>
+                <bioguideID>L000582</bioguideID>
+                <lastname>Lieu</lastname>
+                <firstname>Ted</firstname>
+                <middlename/>
+                <sort-name>LIEU,TED</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ted Lieu</official-name>
+                <formal-name>Mr. Ted Lieu of California</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>33rd</district>
+                <townname>Torrance</townname>
+                <office-building>CHOB</office-building>
+                <office-room>236</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0533</office-zip-suffix>
+                <phone>(202) 225-3976</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="21" />
+                <committee comcode="JU00" rank="14" />
+                <subcommittee subcomcode="FA13" rank="9" />
+                <subcommittee subcomcode="JU03" rank="9" />
+                <subcommittee subcomcode="JU08" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA34</statedistrict>
+            <member-info>
+                <namelist/>
+                <bioguideID/>
+                <lastname/>
+                <firstname/>
+                <middlename/>
+                <sort-name/>
+                <suffix/>
+                <courtesy/>
+                <prior-congress>0</prior-congress>
+                <official-name/>
+                <formal-name/>
+                <party/>
+                <caucus/>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>34th</district>
+                <townname/>
+                <office-building>LHOB</office-building>
+                <office-room>1226</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0534</office-zip-suffix>
+                <phone>(202) 225-6235</phone>
+                <elected-date date="" />
+                <sworn-date date="" />
+                <footnote-ref>0</footnote-ref>
+                <footnote>Vacancy due to the resignation of Xavier Becerra, January 24, 2017.</footnote>
+            </member-info>
+            <predecessor-info cause="R">
+                <pred-lastname>Becerra</pred-lastname>
+                <pred-firstname>Xavier</pred-firstname>
+                <pred-middlename/>
+                <pred-official-name>Xavier Becerra</pred-official-name>
+                <pred-formal-name>Mr. Becerra</pred-formal-name>
+                <pred-memindex>B000287</pred-memindex>
+                <pred-sort-name>BECERRA,XAVIER</pred-sort-name>
+                <pred-party>D</pred-party>
+                <pred-vacate-date date="20170124">January 24, 2017</pred-vacate-date>
+                <pred-footnote-ref>0</pred-footnote-ref>
+                <pred-footnote>Vacancy due to the resignation of Xavier Becerra, January 24, 2017.</pred-footnote>
+            </predecessor-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA35</statedistrict>
+            <member-info>
+                <namelist>Torres, Norma</namelist>
+                <bioguideID>T000474</bioguideID>
+                <lastname>Torres</lastname>
+                <firstname>Norma</firstname>
+                <middlename>J.</middlename>
+                <sort-name>TORRES,NORMA</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Norma J. Torres</official-name>
+                <formal-name>Mrs. Torres</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>35th</district>
+                <townname>Pomona</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1713</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0535</office-zip-suffix>
+                <phone>(202) 225-6161</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="17" />
+                <committee comcode="II00" rank="10" />
+                <subcommittee subcomcode="FA07" rank="4" />
+                <subcommittee subcomcode="FA18" rank="5" />
+                <subcommittee subcomcode="II10" rank="4" />
+                <subcommittee subcomcode="II24" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA36</statedistrict>
+            <member-info>
+                <namelist>Ruiz, Raul</namelist>
+                <bioguideID>R000599</bioguideID>
+                <lastname>Ruiz</lastname>
+                <firstname>Raul</firstname>
+                <middlename/>
+                <sort-name>RUIZ,RAUL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Raul Ruiz</official-name>
+                <formal-name>Mr. Ruiz</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>36th</district>
+                <townname>Coachella</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1319</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0536</office-zip-suffix>
+                <phone>(202) 225-5330</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="22" />
+                <subcommittee subcomcode="IF02" rank="6" />
+                <subcommittee subcomcode="IF16" rank="5" />
+                <subcommittee subcomcode="IF18" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA37</statedistrict>
+            <member-info>
+                <namelist>Bass, Karen</namelist>
+                <bioguideID>B001270</bioguideID>
+                <lastname>Bass</lastname>
+                <firstname>Karen</firstname>
+                <middlename/>
+                <sort-name>BASS,KAREN</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Karen Bass</official-name>
+                <formal-name>Ms. Bass</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>37th</district>
+                <townname>Los Angeles</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2241</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0537</office-zip-suffix>
+                <phone>(202) 225-7084</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="7" />
+                <committee comcode="JU00" rank="9" />
+                <subcommittee subcomcode="FA16" rank="1" />
+                <subcommittee subcomcode="JU03" rank="5" />
+                <subcommittee subcomcode="JU08" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA38</statedistrict>
+            <member-info>
+                <namelist>Sánchez, Linda</namelist>
+                <bioguideID>S001156</bioguideID>
+                <lastname>Sánchez</lastname>
+                <firstname>Linda</firstname>
+                <middlename>T.</middlename>
+                <sort-name>SANCHEZ,LINDA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Linda T. Sánchez</official-name>
+                <formal-name>Ms. Sánchez</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>38th</district>
+                <townname>Whittier</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2329</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0538</office-zip-suffix>
+                <phone>(202) 225-6676</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="12" />
+                <subcommittee subcomcode="WM01" rank="4" />
+                <subcommittee subcomcode="WM05" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA39</statedistrict>
+            <member-info>
+                <namelist>Royce, Edward</namelist>
+                <bioguideID>R000487</bioguideID>
+                <lastname>Royce</lastname>
+                <firstname>Edward</firstname>
+                <middlename>R.</middlename>
+                <sort-name>ROYCE,EDWARD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Edward R. Royce</official-name>
+                <formal-name>Mr. Royce of California</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>39th</district>
+                <townname>Fullerton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2310</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0539</office-zip-suffix>
+                <phone>(202) 225-4111</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="3" />
+                <committee comcode="FA00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="BA04" rank="3" />
+                <subcommittee subcomcode="BA15" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA40</statedistrict>
+            <member-info>
+                <namelist>Roybal-Allard, Lucille</namelist>
+                <bioguideID>R000486</bioguideID>
+                <lastname>Roybal-Allard</lastname>
+                <firstname>Lucille</firstname>
+                <middlename/>
+                <sort-name>ROYBALALLARD,LUCILLE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Lucille Roybal-Allard</official-name>
+                <formal-name>Ms. Roybal-Allard</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>40th</district>
+                <townname>Downey</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2083</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0540</office-zip-suffix>
+                <phone>(202) 225-1766</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="7" />
+                <subcommittee subcomcode="AP07" rank="2" />
+                <subcommittee subcomcode="AP15" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA41</statedistrict>
+            <member-info>
+                <namelist>Takano, Mark</namelist>
+                <bioguideID>T000472</bioguideID>
+                <lastname>Takano</lastname>
+                <firstname>Mark</firstname>
+                <middlename/>
+                <sort-name>TAKANO,MARK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mark Takano</official-name>
+                <formal-name>Mr. Takano</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>41st</district>
+                <townname>Riverside</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1507</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0541</office-zip-suffix>
+                <phone>(202) 225-2305</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="10" />
+                <committee comcode="SY00" rank="14" />
+                <committee comcode="VR00" rank="2" />
+                <subcommittee subcomcode="ED10" rank="1" />
+                <subcommittee subcomcode="ED13" rank="8" />
+                <subcommittee subcomcode="SY20" rank="8" />
+                <subcommittee subcomcode="VR03" rank="2" />
+                <subcommittee subcomcode="VR10" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA42</statedistrict>
+            <member-info>
+                <namelist>Calvert, Ken</namelist>
+                <bioguideID>C000059</bioguideID>
+                <lastname>Calvert</lastname>
+                <firstname>Ken</firstname>
+                <middlename/>
+                <sort-name>CALVERT,KEN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ken Calvert</official-name>
+                <formal-name>Mr. Calvert</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>42nd</district>
+                <townname>Corona</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2205</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0542</office-zip-suffix>
+                <phone>(202) 225-1986</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="8" />
+                <subcommittee subcomcode="AP02" rank="3" leadership="Vice Chair" />
+                <subcommittee subcomcode="AP06" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AP10" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA43</statedistrict>
+            <member-info>
+                <namelist>Waters, Maxine</namelist>
+                <bioguideID>W000187</bioguideID>
+                <lastname>Waters</lastname>
+                <firstname>Maxine</firstname>
+                <middlename/>
+                <sort-name>WATERS,MAXINE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Maxine Waters</official-name>
+                <formal-name>Ms. Maxine Waters of California</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>43rd</district>
+                <townname>Los Angeles</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2221</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0543</office-zip-suffix>
+                <phone>(202) 225-2201</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="1" />
+                <subcommittee subcomcode="BA01" rank="12" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA04" rank="11" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA09" rank="10" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA15" rank="12" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA16" rank="13" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA20" rank="10" leadership="Ex Officio" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA44</statedistrict>
+            <member-info>
+                <namelist>Barragán, Nanette</namelist>
+                <bioguideID>B001300</bioguideID>
+                <lastname>Barragán</lastname>
+                <firstname>Nanette</firstname>
+                <middlename>Diaz</middlename>
+                <sort-name>BARRAGAN,NANETTE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Nanette Diaz Barragán</official-name>
+                <formal-name>Ms. Barragán</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>44th</district>
+                <townname>San Pedro</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1320</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0544</office-zip-suffix>
+                <phone>(202) 225-8220</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="12" />
+                <committee comcode="II00" rank="13" />
+                <subcommittee subcomcode="HM09" rank="3" />
+                <subcommittee subcomcode="HM11" rank="5" />
+                <subcommittee subcomcode="II06" rank="8" />
+                <subcommittee subcomcode="II13" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA45</statedistrict>
+            <member-info>
+                <namelist>Walters, Mimi</namelist>
+                <bioguideID>W000820</bioguideID>
+                <lastname>Walters</lastname>
+                <firstname>Mimi</firstname>
+                <middlename/>
+                <sort-name>WALTERS,MIMI</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mimi Walters</official-name>
+                <formal-name>Mrs. Mimi Walters of California</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>45th</district>
+                <townname>Irvine</townname>
+                <office-building>CHOB</office-building>
+                <office-room>215</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0545</office-zip-suffix>
+                <phone>(202) 225-5611</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="29" />
+                <subcommittee subcomcode="IF02" rank="8" />
+                <subcommittee subcomcode="IF16" rank="16" />
+                <subcommittee subcomcode="IF17" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA46</statedistrict>
+            <member-info>
+                <namelist>Correa, J.</namelist>
+                <bioguideID>C001110</bioguideID>
+                <lastname>Correa</lastname>
+                <firstname>J.</firstname>
+                <middlename>Luis</middlename>
+                <sort-name>CORREA,J.</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>J. Luis Correa</official-name>
+                <formal-name>Mr. Correa</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>46th</district>
+                <townname>Santa Ana</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1039</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0546</office-zip-suffix>
+                <phone>(202) 225-2965</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="10" />
+                <committee comcode="VR00" rank="7" />
+                <subcommittee subcomcode="HM09" rank="1" />
+                <subcommittee subcomcode="HM11" rank="3" />
+                <subcommittee subcomcode="VR03" rank="5" />
+                <subcommittee subcomcode="VR10" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA47</statedistrict>
+            <member-info>
+                <namelist>Lowenthal, Alan</namelist>
+                <bioguideID>L000579</bioguideID>
+                <lastname>Lowenthal</lastname>
+                <firstname>Alan</firstname>
+                <middlename>S.</middlename>
+                <sort-name>LOWENTHAL,ALAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Alan S. Lowenthal</official-name>
+                <formal-name>Mr. Lowenthal</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>47th</district>
+                <townname>Long Beach</townname>
+                <office-building>CHOB</office-building>
+                <office-room>125</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0547</office-zip-suffix>
+                <phone>(202) 225-7924</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="8" />
+                <committee comcode="PW00" rank="25" />
+                <subcommittee subcomcode="II06" rank="1" />
+                <subcommittee subcomcode="II10" rank="3" />
+                <subcommittee subcomcode="PW02" rank="5" />
+                <subcommittee subcomcode="PW07" rank="5" />
+                <subcommittee subcomcode="PW12" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA48</statedistrict>
+            <member-info>
+                <namelist>Rohrabacher, Dana</namelist>
+                <bioguideID>R000409</bioguideID>
+                <lastname>Rohrabacher</lastname>
+                <firstname>Dana</firstname>
+                <middlename/>
+                <sort-name>ROHRABACHER,DANA</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Dana Rohrabacher</official-name>
+                <formal-name>Mr. Rohrabacher</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>48th</district>
+                <townname>Costa Mesa</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2300</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0548</office-zip-suffix>
+                <phone>(202) 225-2415</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="4" />
+                <committee comcode="SY00" rank="2" />
+                <subcommittee subcomcode="FA05" rank="2" />
+                <subcommittee subcomcode="FA14" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="SY16" rank="2" />
+                <subcommittee subcomcode="SY18" rank="2" />
+                <subcommittee subcomcode="SY20" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA49</statedistrict>
+            <member-info>
+                <namelist>Issa, Darrell</namelist>
+                <bioguideID>I000056</bioguideID>
+                <lastname>Issa</lastname>
+                <firstname>Darrell</firstname>
+                <middlename>E.</middlename>
+                <sort-name>ISSA,DARRELL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Darrell E. Issa</official-name>
+                <formal-name>Mr. Issa</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>49th</district>
+                <townname>Vista</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2269</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0549</office-zip-suffix>
+                <phone>(202) 225-3906</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="9" />
+                <committee comcode="GO00" rank="3" />
+                <committee comcode="JU00" rank="5" />
+                <subcommittee subcomcode="FA13" rank="3" />
+                <subcommittee subcomcode="FA18" rank="3" />
+                <subcommittee subcomcode="GO25" rank="3" />
+                <subcommittee subcomcode="GO27" rank="3" />
+                <subcommittee subcomcode="JU03" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="JU05" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA50</statedistrict>
+            <member-info>
+                <namelist>Hunter, Duncan</namelist>
+                <bioguideID>H001048</bioguideID>
+                <lastname>Hunter</lastname>
+                <firstname>Duncan</firstname>
+                <middlename/>
+                <sort-name>HUNTER,DUNCAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Duncan Hunter</official-name>
+                <formal-name>Mr. Hunter</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>50th</district>
+                <townname>Alpine</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2429</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0550</office-zip-suffix>
+                <phone>(202) 225-5672</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="13" />
+                <committee comcode="ED00" rank="3" />
+                <committee comcode="PW00" rank="6" />
+                <subcommittee subcomcode="AS28" rank="7" />
+                <subcommittee subcomcode="AS29" rank="4" />
+                <subcommittee subcomcode="ED10" rank="3" />
+                <subcommittee subcomcode="ED14" rank="2" />
+                <subcommittee subcomcode="PW05" rank="5" />
+                <subcommittee subcomcode="PW07" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="PW12" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA51</statedistrict>
+            <member-info>
+                <namelist>Vargas, Juan</namelist>
+                <bioguideID>V000130</bioguideID>
+                <lastname>Vargas</lastname>
+                <firstname>Juan</firstname>
+                <middlename/>
+                <sort-name>VARGAS,JUAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Juan Vargas</official-name>
+                <formal-name>Mr. Vargas</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>51st</district>
+                <townname>San Diego</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1605</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0551</office-zip-suffix>
+                <phone>(202) 225-8045</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="22" />
+                <subcommittee subcomcode="BA01" rank="8" />
+                <subcommittee subcomcode="BA16" rank="10" />
+                <subcommittee subcomcode="BA20" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA52</statedistrict>
+            <member-info>
+                <namelist>Peters, Scott</namelist>
+                <bioguideID>P000608</bioguideID>
+                <lastname>Peters</lastname>
+                <firstname>Scott</firstname>
+                <middlename>H.</middlename>
+                <sort-name>PETERS,SCOTT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Scott H. Peters</official-name>
+                <formal-name>Mr. Peters</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>52nd</district>
+                <townname>San Diego</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1122</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0552</office-zip-suffix>
+                <phone>(202) 225-0508</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="23" />
+                <committee comcode="VR00" rank="10" />
+                <subcommittee subcomcode="IF02" rank="7" />
+                <subcommittee subcomcode="IF03" rank="3" />
+                <subcommittee subcomcode="IF18" rank="3" />
+                <subcommittee subcomcode="VR08" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CA53</statedistrict>
+            <member-info>
+                <namelist>Davis, Susan</namelist>
+                <bioguideID>D000598</bioguideID>
+                <lastname>Davis</lastname>
+                <firstname>Susan</firstname>
+                <middlename>A.</middlename>
+                <sort-name>DAVIS,SUSAN</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Susan A. Davis</official-name>
+                <formal-name>Mrs. Davis of California</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CA">
+                    <state-fullname>California</state-fullname>
+                </state>
+                <district>53rd</district>
+                <townname>San Diego</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1214</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0553</office-zip-suffix>
+                <phone>(202) 225-2040</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="3" />
+                <committee comcode="ED00" rank="2" />
+                <subcommittee subcomcode="AS28" rank="2" />
+                <subcommittee subcomcode="AS29" rank="2" />
+                <subcommittee subcomcode="ED13" rank="1" />
+                <subcommittee subcomcode="ED14" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CO01</statedistrict>
+            <member-info>
+                <namelist>DeGette, Diana</namelist>
+                <bioguideID>D000197</bioguideID>
+                <lastname>DeGette</lastname>
+                <firstname>Diana</firstname>
+                <middlename/>
+                <sort-name>DEGETTE,DIANA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Diana DeGette</official-name>
+                <formal-name>Ms. DeGette</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CO">
+                    <state-fullname>Colorado</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Denver</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2111</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0601</office-zip-suffix>
+                <phone>(202) 225-4431</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="6" />
+                <subcommittee subcomcode="IF02" rank="1" />
+                <subcommittee subcomcode="IF14" rank="13" />
+                <subcommittee subcomcode="IF18" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CO02</statedistrict>
+            <member-info>
+                <namelist>Polis, Jared</namelist>
+                <bioguideID>P000598</bioguideID>
+                <lastname>Polis</lastname>
+                <firstname>Jared</firstname>
+                <middlename/>
+                <sort-name>POLIS,JARED</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jared Polis</official-name>
+                <formal-name>Mr. Polis</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CO">
+                    <state-fullname>Colorado</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Boulder</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1727</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0602</office-zip-suffix>
+                <phone>(202) 225-2161</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="6" />
+                <committee comcode="RU00" rank="4" />
+                <committee comcode="SO00" rank="3" />
+                <subcommittee subcomcode="ED13" rank="6" />
+                <subcommittee subcomcode="ED14" rank="1" />
+                <subcommittee subcomcode="RU02" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CO03</statedistrict>
+            <member-info>
+                <namelist>Tipton, Scott</namelist>
+                <bioguideID>T000470</bioguideID>
+                <lastname>Tipton</lastname>
+                <firstname>Scott</firstname>
+                <middlename>R.</middlename>
+                <sort-name>TIPTON,SCOTT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Scott R. Tipton</official-name>
+                <formal-name>Mr. Tipton</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CO">
+                    <state-fullname>Colorado</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Cortez</townname>
+                <office-building>CHOB</office-building>
+                <office-room>218</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0603</office-zip-suffix>
+                <phone>(202) 225-4761</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="19" />
+                <committee comcode="II00" rank="11" />
+                <subcommittee subcomcode="BA01" rank="5" />
+                <subcommittee subcomcode="BA09" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="BA15" rank="9" />
+                <subcommittee subcomcode="II06" rank="7" />
+                <subcommittee subcomcode="II10" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CO04</statedistrict>
+            <member-info>
+                <namelist>Buck, Ken</namelist>
+                <bioguideID>B001297</bioguideID>
+                <lastname>Buck</lastname>
+                <firstname>Ken</firstname>
+                <middlename/>
+                <sort-name>BUCK,KEN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ken Buck</official-name>
+                <formal-name>Mr. Buck</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CO">
+                    <state-fullname>Colorado</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Windsor</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1130</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0604</office-zip-suffix>
+                <phone>(202) 225-4676</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="JU00" rank="18" />
+                <committee comcode="RU00" rank="8" />
+                <subcommittee subcomcode="JU01" rank="6" />
+                <subcommittee subcomcode="JU05" rank="5" />
+                <subcommittee subcomcode="RU02" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CO05</statedistrict>
+            <member-info>
+                <namelist>Lamborn, Doug</namelist>
+                <bioguideID>L000564</bioguideID>
+                <lastname>Lamborn</lastname>
+                <firstname>Doug</firstname>
+                <middlename/>
+                <sort-name>LAMBORN,DOUG</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Doug Lamborn</official-name>
+                <formal-name>Mr. Lamborn</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CO">
+                    <state-fullname>Colorado</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Colorado Springs</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2402</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0605</office-zip-suffix>
+                <phone>(202) 225-4422</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="11" />
+                <committee comcode="II00" rank="4" />
+                <subcommittee subcomcode="AS26" rank="9" />
+                <subcommittee subcomcode="AS29" rank="3" />
+                <subcommittee subcomcode="II06" rank="3" />
+                <subcommittee subcomcode="II13" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CO06</statedistrict>
+            <member-info>
+                <namelist>Coffman, Mike</namelist>
+                <bioguideID>C001077</bioguideID>
+                <lastname>Coffman</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>COFFMAN,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mike Coffman</official-name>
+                <formal-name>Mr. Coffman</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="CO">
+                    <state-fullname>Colorado</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Aurora</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2443</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0606</office-zip-suffix>
+                <phone>(202) 225-7882</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="14" />
+                <committee comcode="VR00" rank="3" />
+                <subcommittee subcomcode="AS02" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AS29" rank="8" />
+                <subcommittee subcomcode="VR09" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CO07</statedistrict>
+            <member-info>
+                <namelist>Perlmutter, Ed</namelist>
+                <bioguideID>P000593</bioguideID>
+                <lastname>Perlmutter</lastname>
+                <firstname>Ed</firstname>
+                <middlename/>
+                <sort-name>PERLMUTTER,ED</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ed Perlmutter</official-name>
+                <formal-name>Mr. Perlmutter</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CO">
+                    <state-fullname>Colorado</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Golden</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1410</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0607</office-zip-suffix>
+                <phone>(202) 225-2645</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="14" />
+                <committee comcode="SY00" rank="11" />
+                <subcommittee subcomcode="BA01" rank="1" />
+                <subcommittee subcomcode="SY16" rank="6" />
+                <subcommittee subcomcode="SY21" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CT01</statedistrict>
+            <member-info>
+                <namelist>Larson, John</namelist>
+                <bioguideID>L000557</bioguideID>
+                <lastname>Larson</lastname>
+                <firstname>John</firstname>
+                <middlename>B.</middlename>
+                <sort-name>LARSON,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John B. Larson</official-name>
+                <formal-name>Mr. Larson of Connecticut</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CT">
+                    <state-fullname>Connecticut</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>East Hartford</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1501</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0701</office-zip-suffix>
+                <phone>(202) 225-2265</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="6" />
+                <subcommittee subcomcode="WM01" rank="1" />
+                <subcommittee subcomcode="WM05" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CT02</statedistrict>
+            <member-info>
+                <namelist>Courtney, Joe</namelist>
+                <bioguideID>C001069</bioguideID>
+                <lastname>Courtney</lastname>
+                <firstname>Joe</firstname>
+                <middlename/>
+                <sort-name>COURTNEY,JOE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Joe Courtney</official-name>
+                <formal-name>Mr. Courtney</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CT">
+                    <state-fullname>Connecticut</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Vernon</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2348</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0702</office-zip-suffix>
+                <phone>(202) 225-2076</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="8" />
+                <committee comcode="ED00" rank="4" />
+                <subcommittee subcomcode="AS03" rank="2" />
+                <subcommittee subcomcode="AS28" rank="1" />
+                <subcommittee subcomcode="ED02" rank="7" />
+                <subcommittee subcomcode="ED13" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CT03</statedistrict>
+            <member-info>
+                <namelist>DeLauro, Rosa</namelist>
+                <bioguideID>D000216</bioguideID>
+                <lastname>DeLauro</lastname>
+                <firstname>Rosa</firstname>
+                <middlename>L.</middlename>
+                <sort-name>DELAURO,ROSA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Rosa L. DeLauro</official-name>
+                <formal-name>Ms. DeLauro</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CT">
+                    <state-fullname>Connecticut</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>New Haven</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2413</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0703</office-zip-suffix>
+                <phone>(202) 225-3661</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="5" />
+                <subcommittee subcomcode="AP01" rank="2" />
+                <subcommittee subcomcode="AP07" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CT04</statedistrict>
+            <member-info>
+                <namelist>Himes, James</namelist>
+                <bioguideID>H001047</bioguideID>
+                <lastname>Himes</lastname>
+                <firstname>James</firstname>
+                <middlename>A.</middlename>
+                <sort-name>HIMES,JAMES</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>James A. Himes</official-name>
+                <formal-name>Mr. Himes</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CT">
+                    <state-fullname>Connecticut</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Cos Cob</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1227</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0704</office-zip-suffix>
+                <phone>(202) 225-5541</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="15" />
+                <committee comcode="IG00" rank="2" />
+                <subcommittee subcomcode="BA01" rank="3" />
+                <subcommittee subcomcode="BA16" rank="5" />
+                <subcommittee subcomcode="IG01" rank="2" />
+                <subcommittee subcomcode="IG02" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>CT05</statedistrict>
+            <member-info>
+                <namelist>Esty, Elizabeth</namelist>
+                <bioguideID>E000293</bioguideID>
+                <lastname>Esty</lastname>
+                <firstname>Elizabeth</firstname>
+                <middlename>H.</middlename>
+                <sort-name>ESTY,ELIZABETH</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Elizabeth H. Esty</official-name>
+                <formal-name>Ms. Esty of Connecticut</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="CT">
+                    <state-fullname>Connecticut</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Cheshire</townname>
+                <office-building>CHOB</office-building>
+                <office-room>221</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0705</office-zip-suffix>
+                <phone>(202) 225-4476</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="PW00" rank="18" />
+                <committee comcode="SY00" rank="6" />
+                <committee comcode="VR00" rank="9" />
+                <subcommittee subcomcode="PW02" rank="10" />
+                <subcommittee subcomcode="PW12" rank="8" />
+                <subcommittee subcomcode="PW14" rank="10" />
+                <subcommittee subcomcode="SY15" rank="2" />
+                <subcommittee subcomcode="VR09" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>DC00</statedistrict>
+            <member-info>
+                <namelist>Norton, Eleanor</namelist>
+                <bioguideID>N000147</bioguideID>
+                <lastname>Norton</lastname>
+                <firstname>Eleanor</firstname>
+                <middlename>Holmes</middlename>
+                <sort-name>NORTON,ELEANOR</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Eleanor Holmes Norton</official-name>
+                <formal-name>Ms. Norton</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="DC">
+                    <state-fullname>District of Columbia</state-fullname>
+                </state>
+                <district>Delegate</district>
+                <townname>District of Columbia</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2136</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>5101</office-zip-suffix>
+                <phone>(202) 225-8050</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="3" />
+                <committee comcode="PW00" rank="2" />
+                <subcommittee subcomcode="GO24" rank="3" />
+                <subcommittee subcomcode="GO27" rank="3" />
+                <subcommittee subcomcode="PW05" rank="6" />
+                <subcommittee subcomcode="PW07" rank="6" />
+                <subcommittee subcomcode="PW12" rank="1" />
+                <subcommittee subcomcode="PW13" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>DE00</statedistrict>
+            <member-info>
+                <namelist>Blunt Rochester, Lisa</namelist>
+                <bioguideID>B001303</bioguideID>
+                <lastname>Blunt Rochester</lastname>
+                <firstname>Lisa</firstname>
+                <middlename/>
+                <sort-name>BLUNTROCHESTER,LISA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Lisa Blunt Rochester</official-name>
+                <formal-name>Ms. Blunt Rochester</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="DE">
+                    <state-fullname>Delaware</state-fullname>
+                </state>
+                <district>At Large</district>
+                <townname>Wilmington</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1123</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0800</office-zip-suffix>
+                <phone>(202) 225-4165</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="20" />
+                <committee comcode="ED00" rank="14" />
+                <subcommittee subcomcode="AG14" rank="6" />
+                <subcommittee subcomcode="AG16" rank="4" />
+                <subcommittee subcomcode="ED02" rank="4" />
+                <subcommittee subcomcode="ED13" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL01</statedistrict>
+            <member-info>
+                <namelist>Gaetz, Matt</namelist>
+                <bioguideID>G000578</bioguideID>
+                <lastname>Gaetz</lastname>
+                <firstname>Matt</firstname>
+                <middlename/>
+                <sort-name>GAETZ,MATT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Matt Gaetz</official-name>
+                <formal-name>Mr. Gaetz</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Fort Walton Beach</townname>
+                <office-building>CHOB</office-building>
+                <office-room>507</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0901</office-zip-suffix>
+                <phone>(202) 225-4136</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="31" />
+                <committee comcode="BU00" rank="20" />
+                <committee comcode="JU00" rank="21" />
+                <subcommittee subcomcode="AS06" rank="3" />
+                <subcommittee subcomcode="AS25" rank="8" />
+                <subcommittee subcomcode="JU03" rank="13" />
+                <subcommittee subcomcode="JU05" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL02</statedistrict>
+            <member-info>
+                <namelist>Dunn, Neal</namelist>
+                <bioguideID>D000628</bioguideID>
+                <lastname>Dunn</lastname>
+                <firstname>Neal</firstname>
+                <middlename>P.</middlename>
+                <sort-name>DUNN,NEAL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Neal P. Dunn</official-name>
+                <formal-name>Mr. Dunn</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Panama City</townname>
+                <office-building>CHOB</office-building>
+                <office-room>423</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0902</office-zip-suffix>
+                <phone>(202) 225-5235</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="25" />
+                <committee comcode="SY00" rank="21" />
+                <committee comcode="VR00" rank="8" />
+                <subcommittee subcomcode="AG14" rank="7" />
+                <subcommittee subcomcode="AG16" rank="11" />
+                <subcommittee subcomcode="SY16" rank="13" />
+                <subcommittee subcomcode="SY20" rank="11" />
+                <subcommittee subcomcode="VR03" rank="4" />
+                <subcommittee subcomcode="VR08" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL03</statedistrict>
+            <member-info>
+                <namelist>Yoho, Ted</namelist>
+                <bioguideID>Y000065</bioguideID>
+                <lastname>Yoho</lastname>
+                <firstname>Ted</firstname>
+                <middlename>S.</middlename>
+                <sort-name>YOHO,TED</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ted S. Yoho</official-name>
+                <formal-name>Mr. Yoho</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Gainesville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>511</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0903</office-zip-suffix>
+                <phone>(202) 225-5744</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="15" />
+                <committee comcode="FA00" rank="17" />
+                <subcommittee subcomcode="AG03" rank="7" />
+                <subcommittee subcomcode="AG14" rank="4" />
+                <subcommittee subcomcode="AG29" rank="6" />
+                <subcommittee subcomcode="FA05" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="FA07" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL04</statedistrict>
+            <member-info>
+                <namelist>Rutherford, John</namelist>
+                <bioguideID>R000609</bioguideID>
+                <lastname>Rutherford</lastname>
+                <firstname>John</firstname>
+                <middlename>H.</middlename>
+                <sort-name>RUTHERFORD,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>John H. Rutherford</official-name>
+                <formal-name>Mr. Rutherford</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Jacksonville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>230</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0904</office-zip-suffix>
+                <phone>(202) 225-2501</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="16" />
+                <committee comcode="VR00" rank="10" />
+                <subcommittee subcomcode="HM11" rank="7" />
+                <subcommittee subcomcode="HM12" rank="4" />
+                <subcommittee subcomcode="VR03" rank="5" />
+                <subcommittee subcomcode="VR10" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL05</statedistrict>
+            <member-info>
+                <namelist>Lawson, Al</namelist>
+                <bioguideID>L000586</bioguideID>
+                <lastname>Lawson</lastname>
+                <firstname>Al</firstname>
+                <middlename/>
+                <sort-name>LAWSON,AL</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Al Lawson, Jr.</official-name>
+                <formal-name>Mr. Lawson of Florida</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Tallahassee</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1337</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0905</office-zip-suffix>
+                <phone>(202) 225-0123</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="16" />
+                <committee comcode="SM00" rank="4" />
+                <subcommittee subcomcode="AG03" rank="6" />
+                <subcommittee subcomcode="AG14" rank="2" />
+                <subcommittee subcomcode="AG16" rank="8" />
+                <subcommittee subcomcode="SM23" rank="4" />
+                <subcommittee subcomcode="SM25" rank="2" />
+                <subcommittee subcomcode="SM26" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL06</statedistrict>
+            <member-info>
+                <namelist>DeSantis, Ron</namelist>
+                <bioguideID>D000621</bioguideID>
+                <lastname>DeSantis</lastname>
+                <firstname>Ron</firstname>
+                <middlename/>
+                <sort-name>DESANTIS,RON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ron DeSantis</official-name>
+                <formal-name>Mr. DeSantis</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Palm Coast</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1524</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0906</office-zip-suffix>
+                <phone>(202) 225-2706</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="15" />
+                <committee comcode="GO00" rank="14" />
+                <committee comcode="JU00" rank="17" />
+                <subcommittee subcomcode="FA07" rank="6" />
+                <subcommittee subcomcode="FA13" rank="4" />
+                <subcommittee subcomcode="GO06" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="GO24" rank="6" />
+                <subcommittee subcomcode="JU03" rank="12" />
+                <subcommittee subcomcode="JU10" rank="2" leadership="Vice Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL07</statedistrict>
+            <member-info>
+                <namelist>Murphy, Stephanie</namelist>
+                <bioguideID>M001202</bioguideID>
+                <lastname>Murphy</lastname>
+                <firstname>Stephanie</firstname>
+                <middlename>N.</middlename>
+                <sort-name>MURPHY,STEPHANIE</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Stephanie N. Murphy</official-name>
+                <formal-name>Mrs. Murphy of Florida</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Winter Park</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1237</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0907</office-zip-suffix>
+                <phone>(202) 225-4035</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="24" />
+                <committee comcode="SM00" rank="3" />
+                <subcommittee subcomcode="AS03" rank="8" />
+                <subcommittee subcomcode="AS26" rank="8" />
+                <subcommittee subcomcode="SM23" rank="1" />
+                <subcommittee subcomcode="SM27" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL08</statedistrict>
+            <member-info>
+                <namelist>Posey, Bill</namelist>
+                <bioguideID>P000599</bioguideID>
+                <lastname>Posey</lastname>
+                <firstname>Bill</firstname>
+                <middlename/>
+                <sort-name>POSEY,BILL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bill Posey</official-name>
+                <formal-name>Mr. Posey</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Rockledge</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2150</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0908</office-zip-suffix>
+                <phone>(202) 225-3671</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="7" />
+                <committee comcode="SY00" rank="6" />
+                <subcommittee subcomcode="BA04" rank="5" />
+                <subcommittee subcomcode="BA15" rank="5" />
+                <subcommittee subcomcode="SY16" rank="5" />
+                <subcommittee subcomcode="SY18" rank="3" />
+                <subcommittee subcomcode="SY21" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL09</statedistrict>
+            <member-info>
+                <namelist>Soto, Darren</namelist>
+                <bioguideID>S001200</bioguideID>
+                <lastname>Soto</lastname>
+                <firstname>Darren</firstname>
+                <middlename/>
+                <sort-name>SOTO,DARREN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Darren Soto</official-name>
+                <formal-name>Mr. Soto</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Kissimmee</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1429</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0909</office-zip-suffix>
+                <phone>(202) 225-9889</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="19" />
+                <committee comcode="II00" rank="14" />
+                <subcommittee subcomcode="AG03" rank="8" />
+                <subcommittee subcomcode="AG22" rank="6" />
+                <subcommittee subcomcode="II06" rank="7" />
+                <subcommittee subcomcode="II15" rank="4" />
+                <subcommittee subcomcode="II24" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL10</statedistrict>
+            <member-info>
+                <namelist>Demings, Val</namelist>
+                <bioguideID>D000627</bioguideID>
+                <lastname>Demings</lastname>
+                <firstname>Val</firstname>
+                <middlename>Butler</middlename>
+                <sort-name>DEMINGS,VAL</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Val Butler Demings</official-name>
+                <formal-name>Mrs. Demings</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Orlando</townname>
+                <office-building>CHOB</office-building>
+                <office-room>238</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0910</office-zip-suffix>
+                <phone>(202) 225-2176</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="12" />
+                <committee comcode="HM00" rank="11" />
+                <subcommittee subcomcode="GO06" rank="2" />
+                <subcommittee subcomcode="GO29" rank="1" />
+                <subcommittee subcomcode="HM08" rank="4" />
+                <subcommittee subcomcode="HM11" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL11</statedistrict>
+            <member-info>
+                <namelist>Webster, Daniel</namelist>
+                <bioguideID>W000806</bioguideID>
+                <lastname>Webster</lastname>
+                <firstname>Daniel</firstname>
+                <middlename/>
+                <sort-name>WEBSTER,DANIEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Daniel Webster</official-name>
+                <formal-name>Mr. Webster of Florida</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Clermont</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1210</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0911</office-zip-suffix>
+                <phone>(202) 225-1002</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="20" />
+                <committee comcode="PW00" rank="11" />
+                <committee comcode="SY00" rank="17" />
+                <subcommittee subcomcode="II10" rank="9" />
+                <subcommittee subcomcode="II13" rank="9" />
+                <subcommittee subcomcode="PW02" rank="4" />
+                <subcommittee subcomcode="PW05" rank="8" />
+                <subcommittee subcomcode="PW14" rank="6" />
+                <subcommittee subcomcode="SY15" rank="7" />
+                <subcommittee subcomcode="SY16" rank="10" />
+                <subcommittee subcomcode="SY20" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL12</statedistrict>
+            <member-info>
+                <namelist>Bilirakis, Gus</namelist>
+                <bioguideID>B001257</bioguideID>
+                <lastname>Bilirakis</lastname>
+                <firstname>Gus</firstname>
+                <middlename>M.</middlename>
+                <sort-name>BILIRAKIS,GUS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Gus M. Bilirakis</official-name>
+                <formal-name>Mr. Bilirakis</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Palm Harbor</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2112</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0912</office-zip-suffix>
+                <phone>(202) 225-5755</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="18" />
+                <committee comcode="VR00" rank="2" />
+                <subcommittee subcomcode="IF14" rank="11" />
+                <subcommittee subcomcode="IF16" rank="9" />
+                <subcommittee subcomcode="IF17" rank="9" />
+                <subcommittee subcomcode="VR03" rank="2" />
+                <subcommittee subcomcode="VR10" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL13</statedistrict>
+            <member-info>
+                <namelist>Crist, Charlie</namelist>
+                <bioguideID>C001111</bioguideID>
+                <lastname>Crist</lastname>
+                <firstname>Charlie</firstname>
+                <middlename/>
+                <sort-name>CRIST,CHARLIE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Charlie Crist</official-name>
+                <formal-name>Mr. Crist</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>St. Petersburg</townname>
+                <office-building>CHOB</office-building>
+                <office-room>427</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0913</office-zip-suffix>
+                <phone>(202) 225-5961</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="25" />
+                <committee comcode="SY00" rank="16" />
+                <subcommittee subcomcode="BA09" rank="9" />
+                <subcommittee subcomcode="BA15" rank="11" />
+                <subcommittee subcomcode="BA20" rank="9" />
+                <subcommittee subcomcode="SY16" rank="7" />
+                <subcommittee subcomcode="SY18" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL14</statedistrict>
+            <member-info>
+                <namelist>Castor, Kathy</namelist>
+                <bioguideID>C001066</bioguideID>
+                <lastname>Castor</lastname>
+                <firstname>Kathy</firstname>
+                <middlename/>
+                <sort-name>CASTOR,KATHY</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kathy Castor</official-name>
+                <formal-name>Ms. Castor of Florida</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Tampa</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2052</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0914</office-zip-suffix>
+                <phone>(202) 225-3376</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="11" />
+                <subcommittee subcomcode="IF02" rank="3" />
+                <subcommittee subcomcode="IF03" rank="6" />
+                <subcommittee subcomcode="IF14" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL15</statedistrict>
+            <member-info>
+                <namelist>Ross, Dennis</namelist>
+                <bioguideID>R000593</bioguideID>
+                <lastname>Ross</lastname>
+                <firstname>Dennis</firstname>
+                <middlename>A.</middlename>
+                <sort-name>ROSS,DENNIS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Dennis A. Ross</official-name>
+                <formal-name>Mr. Ross</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>15th</district>
+                <townname>Lakeland</townname>
+                <office-building>CHOB</office-building>
+                <office-room>436</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0915</office-zip-suffix>
+                <phone>(202) 225-1252</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="13" />
+                <committee comcode="GO00" rank="15" />
+                <subcommittee subcomcode="BA04" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="BA09" rank="5" />
+                <subcommittee subcomcode="BA15" rank="6" />
+                <subcommittee subcomcode="GO24" rank="7" />
+                <subcommittee subcomcode="GO28" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL16</statedistrict>
+            <member-info>
+                <namelist>Buchanan, Vern</namelist>
+                <bioguideID>B001260</bioguideID>
+                <lastname>Buchanan</lastname>
+                <firstname>Vern</firstname>
+                <middlename/>
+                <sort-name>BUCHANAN,VERN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Vern Buchanan</official-name>
+                <formal-name>Mr. Buchanan</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>16th</district>
+                <townname>Sarasota</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2104</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0916</office-zip-suffix>
+                <phone>(202) 225-5015</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="7" />
+                <subcommittee subcomcode="WM01" rank="4" />
+                <subcommittee subcomcode="WM02" rank="5" />
+                <subcommittee subcomcode="WM06" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL17</statedistrict>
+            <member-info>
+                <namelist>Rooney, Thomas</namelist>
+                <bioguideID>R000583</bioguideID>
+                <lastname>Rooney</lastname>
+                <firstname>Thomas</firstname>
+                <middlename>J.</middlename>
+                <sort-name>ROONEY,THOMAS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Thomas J. Rooney</official-name>
+                <formal-name>Mr. Thomas J. Rooney of Florida</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>17th</district>
+                <townname>Okeechobee</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2160</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0917</office-zip-suffix>
+                <phone>(202) 225-5792</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="16" />
+                <committee comcode="IG00" rank="5" />
+                <subcommittee subcomcode="AP01" rank="3" />
+                <subcommittee subcomcode="AP04" rank="5" leadership="Vice Chair" />
+                <subcommittee subcomcode="AP18" rank="3" />
+                <subcommittee subcomcode="IG01" rank="4" />
+                <subcommittee subcomcode="IG02" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL18</statedistrict>
+            <member-info>
+                <namelist>Mast, Brian</namelist>
+                <bioguideID>M001199</bioguideID>
+                <lastname>Mast</lastname>
+                <firstname>Brian</firstname>
+                <middlename>J.</middlename>
+                <sort-name>MAST,BRIAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Brian J. Mast</official-name>
+                <formal-name>Mr. Mast</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>18th</district>
+                <townname>Palm City</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2182</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0918</office-zip-suffix>
+                <phone>(202) 225-3026</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="23" />
+                <committee comcode="PW00" rank="33" />
+                <subcommittee subcomcode="FA13" rank="11" />
+                <subcommittee subcomcode="FA18" rank="7" />
+                <subcommittee subcomcode="PW02" rank="17" />
+                <subcommittee subcomcode="PW07" rank="7" />
+                <subcommittee subcomcode="PW13" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL19</statedistrict>
+            <member-info>
+                <namelist>Rooney, Francis</namelist>
+                <bioguideID>R000607</bioguideID>
+                <lastname>Rooney</lastname>
+                <firstname>Francis</firstname>
+                <middlename/>
+                <sort-name>ROONEY,FRANCIS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Francis Rooney</official-name>
+                <formal-name>Mr. Francis Rooney of Florida</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>19th</district>
+                <townname>Naples</townname>
+                <office-building>CHOB</office-building>
+                <office-room>120</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0919</office-zip-suffix>
+                <phone>(202) 225-2536</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="EC00" rank="6" />
+                <committee comcode="ED00" rank="17" />
+                <committee comcode="FA00" rank="24" />
+                <subcommittee subcomcode="ED02" rank="8" />
+                <subcommittee subcomcode="ED10" rank="7" />
+                <subcommittee subcomcode="FA07" rank="8" />
+                <subcommittee subcomcode="FA14" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL20</statedistrict>
+            <member-info>
+                <namelist>Hastings, Alcee</namelist>
+                <bioguideID>H000324</bioguideID>
+                <lastname>Hastings</lastname>
+                <firstname>Alcee</firstname>
+                <middlename>L.</middlename>
+                <sort-name>HASTINGS,ALCEE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Alcee L. Hastings</official-name>
+                <formal-name>Mr. Hastings</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>20th</district>
+                <townname>Delray Beach</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2353</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0920</office-zip-suffix>
+                <phone>(202) 225-1313</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="RU00" rank="3" />
+                <subcommittee subcomcode="RU02" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL21</statedistrict>
+            <member-info>
+                <namelist>Frankel, Lois</namelist>
+                <bioguideID>F000462</bioguideID>
+                <lastname>Frankel</lastname>
+                <firstname>Lois</firstname>
+                <middlename/>
+                <sort-name>FRANKEL,LOIS</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Lois Frankel</official-name>
+                <formal-name>Ms. Frankel of Florida</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>21st</district>
+                <townname>West Palm Beach</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1037</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0921</office-zip-suffix>
+                <phone>(202) 225-9890</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="11" />
+                <committee comcode="PW00" rank="19" />
+                <subcommittee subcomcode="FA13" rank="4" />
+                <subcommittee subcomcode="FA18" rank="2" />
+                <subcommittee subcomcode="PW02" rank="2" />
+                <subcommittee subcomcode="PW12" rank="19" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL22</statedistrict>
+            <member-info>
+                <namelist>Deutch, Theodore</namelist>
+                <bioguideID>D000610</bioguideID>
+                <lastname>Deutch</lastname>
+                <firstname>Theodore</firstname>
+                <middlename>E.</middlename>
+                <sort-name>DEUTCH,THEODORE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Theodore E. Deutch</official-name>
+                <formal-name>Mr. Deutch</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>22nd</district>
+                <townname>Boca Raton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2447</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0922</office-zip-suffix>
+                <phone>(202) 225-3001</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="6" />
+                <committee comcode="JU00" rank="7" />
+                <committee comcode="SO00" rank="1" />
+                <subcommittee subcomcode="FA05" rank="5" />
+                <subcommittee subcomcode="FA13" rank="1" />
+                <subcommittee subcomcode="JU03" rank="4" />
+                <subcommittee subcomcode="JU08" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL23</statedistrict>
+            <member-info>
+                <namelist>Wasserman Schultz, Debbie</namelist>
+                <bioguideID>W000797</bioguideID>
+                <lastname>Wasserman Schultz</lastname>
+                <firstname>Debbie</firstname>
+                <middlename/>
+                <sort-name>WASSERMANSCHULTZ,DEBBIE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Debbie Wasserman Schultz</official-name>
+                <formal-name>Ms. Wasserman Schultz</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>23rd</district>
+                <townname>Weston</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1114</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0923</office-zip-suffix>
+                <phone>(202) 225-7931</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="13" />
+                <committee comcode="BU00" rank="8" />
+                <subcommittee subcomcode="AP10" rank="3" />
+                <subcommittee subcomcode="AP18" rank="1" />
+                <subcommittee subcomcode="AP24" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL24</statedistrict>
+            <member-info>
+                <namelist>Wilson, Frederica</namelist>
+                <bioguideID>W000808</bioguideID>
+                <lastname>Wilson</lastname>
+                <firstname>Frederica</firstname>
+                <middlename>S.</middlename>
+                <sort-name>WILSON,FREDERICA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Frederica S. Wilson</official-name>
+                <formal-name>Ms. Wilson of Florida</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>24th</district>
+                <townname>Miami Gardens</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2445</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0924</office-zip-suffix>
+                <phone>(202) 225-4506</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="8" />
+                <committee comcode="PW00" rank="23" />
+                <subcommittee subcomcode="ED02" rank="2" />
+                <subcommittee subcomcode="ED14" rank="6" />
+                <subcommittee subcomcode="PW02" rank="3" />
+                <subcommittee subcomcode="PW12" rank="21" />
+                <subcommittee subcomcode="PW14" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL25</statedistrict>
+            <member-info>
+                <namelist>Diaz-Balart, Mario</namelist>
+                <bioguideID>D000600</bioguideID>
+                <lastname>Diaz-Balart</lastname>
+                <firstname>Mario</firstname>
+                <middlename/>
+                <sort-name>DIAZBALART,MARIO</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mario Diaz-Balart</official-name>
+                <formal-name>Mr. Diaz-Balart</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>25th</district>
+                <townname>Miami</townname>
+                <office-building>CHOB</office-building>
+                <office-room>440</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0925</office-zip-suffix>
+                <phone>(202) 225-4211</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="10" />
+                <committee comcode="BU00" rank="2" />
+                <subcommittee subcomcode="AP02" rank="8" />
+                <subcommittee subcomcode="AP04" rank="3" />
+                <subcommittee subcomcode="AP20" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL26</statedistrict>
+            <member-info>
+                <namelist>Curbelo, Carlos</namelist>
+                <bioguideID>C001107</bioguideID>
+                <lastname>Curbelo</lastname>
+                <firstname>Carlos</firstname>
+                <middlename/>
+                <sort-name>CURBELO,CARLOS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Carlos Curbelo</official-name>
+                <formal-name>Mr. Curbelo of Florida</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>26th</district>
+                <townname>Miami</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1404</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0926</office-zip-suffix>
+                <phone>(202) 225-2778</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="23" />
+                <subcommittee subcomcode="WM03" rank="4" />
+                <subcommittee subcomcode="WM06" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>FL27</statedistrict>
+            <member-info>
+                <namelist>Ros-Lehtinen, Ileana</namelist>
+                <bioguideID>R000435</bioguideID>
+                <lastname>Ros-Lehtinen</lastname>
+                <firstname>Ileana</firstname>
+                <middlename/>
+                <sort-name>ROSLEHTINEN,ILEANA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ileana Ros-Lehtinen</official-name>
+                <formal-name>Ms. Ros-Lehtinen</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="FL">
+                    <state-fullname>Florida</state-fullname>
+                </state>
+                <district>27th</district>
+                <townname>Miami</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2206</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>0927</office-zip-suffix>
+                <phone>(202) 225-3931</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="3" />
+                <committee comcode="IG00" rank="6" />
+                <subcommittee subcomcode="FA07" rank="3" />
+                <subcommittee subcomcode="FA13" rank="1" leadership="Chairwoman" />
+                <subcommittee subcomcode="IG01" rank="5" />
+                <subcommittee subcomcode="IG02" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA01</statedistrict>
+            <member-info>
+                <namelist>Carter, Earl</namelist>
+                <bioguideID>C001103</bioguideID>
+                <lastname>Carter</lastname>
+                <firstname>Earl</firstname>
+                <middlename>L. "Buddy"</middlename>
+                <sort-name>CARTER,EARL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Earl L. "Buddy" Carter</official-name>
+                <formal-name>Mr. Carter of Georgia</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Pooler</townname>
+                <office-building>CHOB</office-building>
+                <office-room>432</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1001</office-zip-suffix>
+                <phone>(202) 225-5831</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="31" />
+                <subcommittee subcomcode="IF02" rank="10" />
+                <subcommittee subcomcode="IF14" rank="18" />
+                <subcommittee subcomcode="IF18" rank="13" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA02</statedistrict>
+            <member-info>
+                <namelist>Bishop, Sanford</namelist>
+                <bioguideID>B000490</bioguideID>
+                <lastname>Bishop</lastname>
+                <firstname>Sanford</firstname>
+                <middlename>D.</middlename>
+                <sort-name>BISHOP,SANFORD</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Sanford D. Bishop, Jr.</official-name>
+                <formal-name>Mr. Bishop of Georgia</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Albany</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2407</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1002</office-zip-suffix>
+                <phone>(202) 225-3631</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="8" />
+                <subcommittee subcomcode="AP01" rank="1" />
+                <subcommittee subcomcode="AP18" rank="2" />
+                <subcommittee subcomcode="AP23" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA03</statedistrict>
+            <member-info>
+                <namelist>Ferguson, A.</namelist>
+                <bioguideID>F000465</bioguideID>
+                <lastname>Ferguson</lastname>
+                <firstname>A.</firstname>
+                <middlename>Drew</middlename>
+                <sort-name>FERGUSON,A.</sort-name>
+                <suffix>IV</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>A. Drew Ferguson IV</official-name>
+                <formal-name>Mr. Ferguson</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>West Point</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1032</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1003</office-zip-suffix>
+                <phone>(202) 225-5901</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="22" />
+                <committee comcode="ED00" rank="21" />
+                <committee comcode="PW00" rank="32" />
+                <subcommittee subcomcode="ED02" rank="11" />
+                <subcommittee subcomcode="ED10" rank="8" />
+                <subcommittee subcomcode="PW02" rank="16" />
+                <subcommittee subcomcode="PW12" rank="27" />
+                <subcommittee subcomcode="PW13" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA04</statedistrict>
+            <member-info>
+                <namelist>Johnson, Henry</namelist>
+                <bioguideID>J000288</bioguideID>
+                <lastname>Johnson</lastname>
+                <firstname>Henry</firstname>
+                <middlename>C. "Hank"</middlename>
+                <sort-name>JOHNSON,HENRY</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Henry C. "Hank" Johnson, Jr.</official-name>
+                <formal-name>Mr. Johnson of Georgia</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Lithonia</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2240</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1004</office-zip-suffix>
+                <phone>(202) 225-1605</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="JU00" rank="6" />
+                <committee comcode="PW00" rank="13" />
+                <subcommittee subcomcode="JU03" rank="2" />
+                <subcommittee subcomcode="JU05" rank="2" />
+                <subcommittee subcomcode="PW05" rank="15" />
+                <subcommittee subcomcode="PW12" rank="18" />
+                <subcommittee subcomcode="PW13" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA05</statedistrict>
+            <member-info>
+                <namelist>Lewis, John</namelist>
+                <bioguideID>L000287</bioguideID>
+                <lastname>Lewis</lastname>
+                <firstname>John</firstname>
+                <middlename/>
+                <sort-name>LEWIS,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John Lewis</official-name>
+                <formal-name>Mr. Lewis of Georgia</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Atlanta</townname>
+                <office-building>CHOB</office-building>
+                <office-room>343</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1005</office-zip-suffix>
+                <phone>(202) 225-3801</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IT00" rank="5" />
+                <committee comcode="WM00" rank="3" />
+                <subcommittee subcomcode="WM06" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA06</statedistrict>
+            <member-info>
+                <namelist/>
+                <bioguideID/>
+                <lastname/>
+                <firstname/>
+                <middlename/>
+                <sort-name/>
+                <suffix/>
+                <courtesy/>
+                <prior-congress>0</prior-congress>
+                <official-name/>
+                <formal-name/>
+                <party/>
+                <caucus/>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname/>
+                <office-building>LHOB</office-building>
+                <office-room>1211</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1006</office-zip-suffix>
+                <phone>(202) 225-4501</phone>
+                <elected-date date="" />
+                <sworn-date date="" />
+                <footnote-ref>0</footnote-ref>
+                <footnote>Vacancy due to the resignation of Tom Price, February 10, 2017.</footnote>
+            </member-info>
+            <predecessor-info cause="R">
+                <pred-lastname>Price</pred-lastname>
+                <pred-firstname>Tom</pred-firstname>
+                <pred-middlename/>
+                <pred-official-name>Tom Price</pred-official-name>
+                <pred-formal-name>Mr. Tom Price of Georgia</pred-formal-name>
+                <pred-memindex>P000591</pred-memindex>
+                <pred-sort-name>PRICE,TOM</pred-sort-name>
+                <pred-party>R</pred-party>
+                <pred-vacate-date date="20170210">February 10, 2017</pred-vacate-date>
+                <pred-footnote-ref>0</pred-footnote-ref>
+                <pred-footnote>Vacancy due to the resignation of Tom Price, February 10, 2017.</pred-footnote>
+            </predecessor-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA07</statedistrict>
+            <member-info>
+                <namelist>Woodall, Rob</namelist>
+                <bioguideID>W000810</bioguideID>
+                <lastname>Woodall</lastname>
+                <firstname>Rob</firstname>
+                <middlename/>
+                <sort-name>WOODALL,ROB</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Rob Woodall</official-name>
+                <formal-name>Mr. Woodall</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Lawrenceville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1724</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1007</office-zip-suffix>
+                <phone>(202) 225-4272</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="6" />
+                <committee comcode="PW00" rank="18" />
+                <committee comcode="RU00" rank="3" />
+                <subcommittee subcomcode="PW02" rank="8" />
+                <subcommittee subcomcode="PW05" rank="15" />
+                <subcommittee subcomcode="PW12" rank="15" />
+                <subcommittee subcomcode="RU02" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA08</statedistrict>
+            <member-info>
+                <namelist>Scott, Austin</namelist>
+                <bioguideID>S001189</bioguideID>
+                <lastname>Scott</lastname>
+                <firstname>Austin</firstname>
+                <middlename/>
+                <sort-name>SCOTT,AUSTIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Austin Scott</official-name>
+                <formal-name>Mr. Austin Scott of Georgia</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Tifton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2417</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1008</office-zip-suffix>
+                <phone>(202) 225-6531</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="8" />
+                <committee comcode="AS00" rank="16" />
+                <subcommittee subcomcode="AG16" rank="5" />
+                <subcommittee subcomcode="AG22" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AS03" rank="3" />
+                <subcommittee subcomcode="AS06" rank="6" />
+                <subcommittee subcomcode="AS26" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA09</statedistrict>
+            <member-info>
+                <namelist>Collins, Doug</namelist>
+                <bioguideID>C001093</bioguideID>
+                <lastname>Collins</lastname>
+                <firstname>Doug</firstname>
+                <middlename/>
+                <sort-name>COLLINS,DOUG</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Doug Collins</official-name>
+                <formal-name>Mr. Collins of Georgia</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Gainesville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1504</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1009</office-zip-suffix>
+                <phone>(202) 225-9893</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="JU00" rank="16" />
+                <committee comcode="RU00" rank="5" />
+                <subcommittee subcomcode="JU03" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="JU05" rank="4" />
+                <subcommittee subcomcode="RU04" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA10</statedistrict>
+            <member-info>
+                <namelist>Hice, Jody</namelist>
+                <bioguideID>H001071</bioguideID>
+                <lastname>Hice</lastname>
+                <firstname>Jody</firstname>
+                <middlename>B.</middlename>
+                <sort-name>HICE,JODY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jody B. Hice</official-name>
+                <formal-name>Mr. Jody B. Hice of Georgia</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Monroe</townname>
+                <office-building>CHOB</office-building>
+                <office-room>324</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1010</office-zip-suffix>
+                <phone>(202) 225-4101</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="18" />
+                <committee comcode="II00" rank="17" />
+                <subcommittee subcomcode="GO06" rank="7" />
+                <subcommittee subcomcode="GO24" rank="2" leadership="Vice Chair" />
+                <subcommittee subcomcode="II06" rank="11" />
+                <subcommittee subcomcode="II13" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA11</statedistrict>
+            <member-info>
+                <namelist>Loudermilk, Barry</namelist>
+                <bioguideID>L000583</bioguideID>
+                <lastname>Loudermilk</lastname>
+                <firstname>Barry</firstname>
+                <middlename/>
+                <sort-name>LOUDERMILK,BARRY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Barry Loudermilk</official-name>
+                <formal-name>Mr. Loudermilk</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Cassville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>329</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1011</office-zip-suffix>
+                <phone>(202) 225-2931</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="27" />
+                <committee comcode="HA00" rank="6" />
+                <committee comcode="JL00" rank="3" />
+                <committee comcode="SY00" rank="14" />
+                <subcommittee subcomcode="BA09" rank="9" />
+                <subcommittee subcomcode="BA15" rank="13" />
+                <subcommittee subcomcode="SY18" rank="8" />
+                <subcommittee subcomcode="SY21" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA12</statedistrict>
+            <member-info>
+                <namelist>Allen, Rick</namelist>
+                <bioguideID>A000372</bioguideID>
+                <lastname>Allen</lastname>
+                <firstname>Rick</firstname>
+                <middlename>W.</middlename>
+                <sort-name>ALLEN,RICK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Rick W. Allen</official-name>
+                <formal-name>Mr. Allen</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Augusta</townname>
+                <office-building>CHOB</office-building>
+                <office-room>426</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1012</office-zip-suffix>
+                <phone>(202) 225-2823</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="16" />
+                <committee comcode="ED00" rank="15" />
+                <subcommittee subcomcode="AG15" rank="5" />
+                <subcommittee subcomcode="AG16" rank="7" />
+                <subcommittee subcomcode="ED02" rank="6" />
+                <subcommittee subcomcode="ED13" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA13</statedistrict>
+            <member-info>
+                <namelist>Scott, David</namelist>
+                <bioguideID>S001157</bioguideID>
+                <lastname>Scott</lastname>
+                <firstname>David</firstname>
+                <middlename/>
+                <sort-name>SCOTT,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David Scott</official-name>
+                <formal-name>Mr. David Scott of Georgia</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>Atlanta</townname>
+                <office-building>CHOB</office-building>
+                <office-room>225</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1013</office-zip-suffix>
+                <phone>(202) 225-2939</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="2" />
+                <committee comcode="BA00" rank="9" />
+                <subcommittee subcomcode="AG16" rank="5" />
+                <subcommittee subcomcode="AG22" rank="1" />
+                <subcommittee subcomcode="BA15" rank="4" />
+                <subcommittee subcomcode="BA16" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GA14</statedistrict>
+            <member-info>
+                <namelist>Graves, Tom</namelist>
+                <bioguideID>G000560</bioguideID>
+                <lastname>Graves</lastname>
+                <firstname>Tom</firstname>
+                <middlename/>
+                <sort-name>GRAVES,TOM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tom Graves</official-name>
+                <formal-name>Mr. Graves of Georgia</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="GA">
+                    <state-fullname>Georgia</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Ranger</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2078</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1014</office-zip-suffix>
+                <phone>(202) 225-5211</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="12" />
+                <subcommittee subcomcode="AP02" rank="9" />
+                <subcommittee subcomcode="AP20" rank="7" />
+                <subcommittee subcomcode="AP23" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>GU00</statedistrict>
+            <member-info>
+                <namelist>Bordallo, Madeleine</namelist>
+                <bioguideID>B001245</bioguideID>
+                <lastname>Bordallo</lastname>
+                <firstname>Madeleine</firstname>
+                <middlename>Z.</middlename>
+                <sort-name>BORDALLO,MADELEINE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Madeleine Z. Bordallo</official-name>
+                <formal-name>Ms. Bordallo</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="GU">
+                    <state-fullname>Guam</state-fullname>
+                </state>
+                <district>Delegate</district>
+                <townname>Hagatna</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2441</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>5301</office-zip-suffix>
+                <phone>(202) 225-1188</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="7" />
+                <committee comcode="II00" rank="3" />
+                <subcommittee subcomcode="AS03" rank="1" />
+                <subcommittee subcomcode="AS28" rank="4" />
+                <subcommittee subcomcode="II13" rank="7" />
+                <subcommittee subcomcode="II24" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>HI01</statedistrict>
+            <member-info>
+                <namelist>Hanabusa, Colleen</namelist>
+                <bioguideID>H001050</bioguideID>
+                <lastname>Hanabusa</lastname>
+                <firstname>Colleen</firstname>
+                <middlename/>
+                <sort-name>HANABUSA,COLLEEN</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Colleen Hanabusa</official-name>
+                <formal-name>Ms. Hanabusa</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="HI">
+                    <state-fullname>Hawaii</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Honolulu</townname>
+                <office-building>CHOB</office-building>
+                <office-room>422</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1101</office-zip-suffix>
+                <phone>(202) 225-2726</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="18" />
+                <committee comcode="II00" rank="12" />
+                <committee comcode="SY00" rank="15" />
+                <subcommittee subcomcode="AS28" rank="8" />
+                <subcommittee subcomcode="AS29" rank="7" />
+                <subcommittee subcomcode="II10" rank="1" />
+                <subcommittee subcomcode="II24" rank="6" />
+                <subcommittee subcomcode="SY18" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>HI02</statedistrict>
+            <member-info>
+                <namelist>Gabbard, Tulsi</namelist>
+                <bioguideID>G000571</bioguideID>
+                <lastname>Gabbard</lastname>
+                <firstname>Tulsi</firstname>
+                <middlename/>
+                <sort-name>GABBARD,TULSI</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tulsi Gabbard</official-name>
+                <formal-name>Ms. Gabbard</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="HI">
+                    <state-fullname>Hawaii</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Kailua</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1433</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1102</office-zip-suffix>
+                <phone>(202) 225-4906</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="13" />
+                <committee comcode="FA00" rank="12" />
+                <subcommittee subcomcode="AS03" rank="3" />
+                <subcommittee subcomcode="AS26" rank="6" />
+                <subcommittee subcomcode="FA05" rank="6" />
+                <subcommittee subcomcode="FA13" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IA01</statedistrict>
+            <member-info>
+                <namelist>Blum, Rod</namelist>
+                <bioguideID>B001294</bioguideID>
+                <lastname>Blum</lastname>
+                <firstname>Rod</firstname>
+                <middlename/>
+                <sort-name>BLUM,ROD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Rod Blum</official-name>
+                <formal-name>Mr. Blum</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IA">
+                    <state-fullname>Iowa</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Dubuque</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1108</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1501</office-zip-suffix>
+                <phone>(202) 225-2911</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="17" />
+                <committee comcode="SM00" rank="8" />
+                <subcommittee subcomcode="GO24" rank="8" />
+                <subcommittee subcomcode="SM24" rank="2" />
+                <subcommittee subcomcode="SM25" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IA02</statedistrict>
+            <member-info>
+                <namelist>Loebsack, David</namelist>
+                <bioguideID>L000565</bioguideID>
+                <lastname>Loebsack</lastname>
+                <firstname>David</firstname>
+                <middlename/>
+                <sort-name>LOEBSACK,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David Loebsack</official-name>
+                <formal-name>Mr. Loebsack</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IA">
+                    <state-fullname>Iowa</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Iowa City</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1527</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1502</office-zip-suffix>
+                <phone>(202) 225-6576</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="18" />
+                <subcommittee subcomcode="IF03" rank="10" />
+                <subcommittee subcomcode="IF16" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IA03</statedistrict>
+            <member-info>
+                <namelist>Young, David</namelist>
+                <bioguideID>Y000066</bioguideID>
+                <lastname>Young</lastname>
+                <firstname>David</firstname>
+                <middlename/>
+                <sort-name>YOUNG,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David Young</official-name>
+                <formal-name>Mr. Young of Iowa</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IA">
+                    <state-fullname>Iowa</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Van Meter</townname>
+                <office-building>CHOB</office-building>
+                <office-room>240</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1503</office-zip-suffix>
+                <phone>(202) 225-5476</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="25" />
+                <subcommittee subcomcode="AP01" rank="6" />
+                <subcommittee subcomcode="AP20" rank="5" />
+                <subcommittee subcomcode="AP23" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IA04</statedistrict>
+            <member-info>
+                <namelist>King, Steve</namelist>
+                <bioguideID>K000362</bioguideID>
+                <lastname>King</lastname>
+                <firstname>Steve</firstname>
+                <middlename/>
+                <sort-name>KING,STEVE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steve King</official-name>
+                <formal-name>Mr. King of Iowa</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IA">
+                    <state-fullname>Iowa</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Kiron</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2210</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1504</office-zip-suffix>
+                <phone>(202) 225-4426</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="4" />
+                <committee comcode="JU00" rank="6" />
+                <committee comcode="SM00" rank="2" />
+                <subcommittee subcomcode="AG03" rank="2" />
+                <subcommittee subcomcode="AG29" rank="3" />
+                <subcommittee subcomcode="JU01" rank="4" />
+                <subcommittee subcomcode="JU10" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="SM23" rank="2" />
+                <subcommittee subcomcode="SM25" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>ID01</statedistrict>
+            <member-info>
+                <namelist>Labrador, Raúl</namelist>
+                <bioguideID>L000573</bioguideID>
+                <lastname>Labrador</lastname>
+                <firstname>Raúl</firstname>
+                <middlename>R.</middlename>
+                <sort-name>LABRADOR,RAUL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Raúl R. Labrador</official-name>
+                <formal-name>Mr. Labrador</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="ID">
+                    <state-fullname>Idaho</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Eagle</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1523</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1201</office-zip-suffix>
+                <phone>(202) 225-6611</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="10" />
+                <committee comcode="JU00" rank="14" />
+                <subcommittee subcomcode="II10" rank="5" />
+                <subcommittee subcomcode="II15" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="JU01" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="JU03" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>ID02</statedistrict>
+            <member-info>
+                <namelist>Simpson, Michael</namelist>
+                <bioguideID>S001148</bioguideID>
+                <lastname>Simpson</lastname>
+                <firstname>Michael</firstname>
+                <middlename>K.</middlename>
+                <sort-name>SIMPSON,MICHAEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Michael K. Simpson</official-name>
+                <formal-name>Mr. Simpson</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="ID">
+                    <state-fullname>Idaho</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Idaho Falls</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2084</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1202</office-zip-suffix>
+                <phone>(202) 225-5531</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="5" />
+                <subcommittee subcomcode="AP06" rank="2" />
+                <subcommittee subcomcode="AP07" rank="2" />
+                <subcommittee subcomcode="AP10" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL01</statedistrict>
+            <member-info>
+                <namelist>Rush, Bobby</namelist>
+                <bioguideID>R000515</bioguideID>
+                <lastname>Rush</lastname>
+                <firstname>Bobby</firstname>
+                <middlename>L.</middlename>
+                <sort-name>RUSH,BOBBY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bobby L. Rush</official-name>
+                <formal-name>Mr. Rush</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Chicago</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2188</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1301</office-zip-suffix>
+                <phone>(202) 225-4372</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="2" />
+                <subcommittee subcomcode="IF03" rank="1" />
+                <subcommittee subcomcode="IF16" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL02</statedistrict>
+            <member-info>
+                <namelist>Kelly, Robin</namelist>
+                <bioguideID>K000385</bioguideID>
+                <lastname>Kelly</lastname>
+                <firstname>Robin</firstname>
+                <middlename>L.</middlename>
+                <sort-name>KELLY,ROBIN</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Robin L. Kelly</official-name>
+                <formal-name>Ms. Kelly of Illinois</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Matteson</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1239</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1302</office-zip-suffix>
+                <phone>(202) 225-0773</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="14" />
+                <committee comcode="GO00" rank="8" />
+                <subcommittee subcomcode="FA07" rank="3" />
+                <subcommittee subcomcode="FA14" rank="6" />
+                <subcommittee subcomcode="GO25" rank="1" />
+                <subcommittee subcomcode="GO27" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL03</statedistrict>
+            <member-info>
+                <namelist>Lipinski, Daniel</namelist>
+                <bioguideID>L000563</bioguideID>
+                <lastname>Lipinski</lastname>
+                <firstname>Daniel</firstname>
+                <middlename/>
+                <sort-name>LIPINSKI,DANIEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Daniel Lipinski</official-name>
+                <formal-name>Mr. Lipinski</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Western Springs</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2346</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1303</office-zip-suffix>
+                <phone>(202) 225-5701</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="PW00" rank="9" />
+                <committee comcode="SY00" rank="3" />
+                <subcommittee subcomcode="PW05" rank="3" />
+                <subcommittee subcomcode="PW12" rank="17" />
+                <subcommittee subcomcode="PW14" rank="14" />
+                <subcommittee subcomcode="SY15" rank="1" />
+                <subcommittee subcomcode="SY16" rank="5" />
+                <subcommittee subcomcode="SY20" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL04</statedistrict>
+            <member-info>
+                <namelist>Gutiérrez, Luis</namelist>
+                <bioguideID>G000535</bioguideID>
+                <lastname>Gutiérrez</lastname>
+                <firstname>Luis</firstname>
+                <middlename>V.</middlename>
+                <sort-name>GUTIERREZ,LUIS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Luis V. Gutiérrez</official-name>
+                <formal-name>Mr. Gutiérrez</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Chicago</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2408</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1304</office-zip-suffix>
+                <phone>(202) 225-8203</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="JU00" rank="8" />
+                <subcommittee subcomcode="JU01" rank="2" />
+                <subcommittee subcomcode="JU03" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL05</statedistrict>
+            <member-info>
+                <namelist>Quigley, Mike</namelist>
+                <bioguideID>Q000023</bioguideID>
+                <lastname>Quigley</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>QUIGLEY,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mike Quigley</official-name>
+                <formal-name>Mr. Quigley</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Chicago</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2458</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1305</office-zip-suffix>
+                <phone>(202) 225-4061</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="16" />
+                <committee comcode="IG00" rank="6" />
+                <subcommittee subcomcode="AP20" rank="2" />
+                <subcommittee subcomcode="AP23" rank="1" />
+                <subcommittee subcomcode="IG02" rank="4" />
+                <subcommittee subcomcode="IG03" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL06</statedistrict>
+            <member-info>
+                <namelist>Roskam, Peter</namelist>
+                <bioguideID>R000580</bioguideID>
+                <lastname>Roskam</lastname>
+                <firstname>Peter</firstname>
+                <middlename>J.</middlename>
+                <sort-name>ROSKAM,PETER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Peter J. Roskam</official-name>
+                <formal-name>Mr. Roskam</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Wheaton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2246</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1306</office-zip-suffix>
+                <phone>(202) 225-4561</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="6" />
+                <subcommittee subcomcode="WM02" rank="4" />
+                <subcommittee subcomcode="WM05" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL07</statedistrict>
+            <member-info>
+                <namelist>Davis, Danny</namelist>
+                <bioguideID>D000096</bioguideID>
+                <lastname>Davis</lastname>
+                <firstname>Danny</firstname>
+                <middlename>K.</middlename>
+                <sort-name>DAVIS,DANNY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Danny K. Davis</official-name>
+                <formal-name>Mr. Danny K. Davis of Illinois</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Chicago</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2159</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1307</office-zip-suffix>
+                <phone>(202) 225-5006</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="11" />
+                <subcommittee subcomcode="WM03" rank="1" />
+                <subcommittee subcomcode="WM04" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL08</statedistrict>
+            <member-info>
+                <namelist>Krishnamoorthi, Raja</namelist>
+                <bioguideID>K000391</bioguideID>
+                <lastname>Krishnamoorthi</lastname>
+                <firstname>Raja</firstname>
+                <middlename/>
+                <sort-name>KRISHNAMOORTHI,RAJA</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Raja Krishnamoorthi</official-name>
+                <formal-name>Mr. Krishnamoorthi</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Schaumburg</townname>
+                <office-building>CHOB</office-building>
+                <office-room>515</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1308</office-zip-suffix>
+                <phone>(202) 225-3711</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="15" />
+                <committee comcode="GO00" rank="13" />
+                <subcommittee subcomcode="ED10" rank="6" />
+                <subcommittee subcomcode="ED13" rank="5" />
+                <subcommittee subcomcode="GO25" rank="5" />
+                <subcommittee subcomcode="GO27" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL09</statedistrict>
+            <member-info>
+                <namelist>Schakowsky, Janice</namelist>
+                <bioguideID>S001145</bioguideID>
+                <lastname>Schakowsky</lastname>
+                <firstname>Janice</firstname>
+                <middlename>D.</middlename>
+                <sort-name>SCHAKOWSKY,JANICE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Janice D. Schakowsky</official-name>
+                <formal-name>Ms. Schakowsky</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Evanston</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2367</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1309</office-zip-suffix>
+                <phone>(202) 225-2111</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="14" />
+                <committee comcode="IF00" rank="8" />
+                <subcommittee subcomcode="IF02" rank="2" />
+                <subcommittee subcomcode="IF14" rank="3" />
+                <subcommittee subcomcode="IF17" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL10</statedistrict>
+            <member-info>
+                <namelist>Schneider, Bradley</namelist>
+                <bioguideID>S001190</bioguideID>
+                <lastname>Schneider</lastname>
+                <firstname>Bradley</firstname>
+                <middlename>Scott</middlename>
+                <sort-name>SCHNEIDER,BRADLEY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>113</prior-congress>
+                <official-name>Bradley Scott Schneider</official-name>
+                <formal-name>Mr. Schneider</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Deerfield</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1432</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1310</office-zip-suffix>
+                <phone>(202) 225-4835</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="18" />
+                <committee comcode="JU00" rank="17" />
+                <committee comcode="SM00" rank="9" />
+                <subcommittee subcomcode="FA13" rank="7" />
+                <subcommittee subcomcode="FA18" rank="6" />
+                <subcommittee subcomcode="SM25" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL11</statedistrict>
+            <member-info>
+                <namelist>Foster, Bill</namelist>
+                <bioguideID>F000454</bioguideID>
+                <lastname>Foster</lastname>
+                <firstname>Bill</firstname>
+                <middlename/>
+                <sort-name>FOSTER,BILL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bill Foster</official-name>
+                <formal-name>Mr. Foster</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Naperville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1224</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1311</office-zip-suffix>
+                <phone>(202) 225-3515</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="16" />
+                <committee comcode="SY00" rank="13" />
+                <subcommittee subcomcode="BA01" rank="4" />
+                <subcommittee subcomcode="BA16" rank="7" />
+                <subcommittee subcomcode="BA20" rank="3" />
+                <subcommittee subcomcode="SY16" rank="8" />
+                <subcommittee subcomcode="SY20" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL12</statedistrict>
+            <member-info>
+                <namelist>Bost, Mike</namelist>
+                <bioguideID>B001295</bioguideID>
+                <lastname>Bost</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>BOST,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mike Bost</official-name>
+                <formal-name>Mr. Bost</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Murphysboro</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1440</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1312</office-zip-suffix>
+                <phone>(202) 225-5661</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="17" />
+                <committee comcode="PW00" rank="25" />
+                <committee comcode="VR00" rank="6" />
+                <subcommittee subcomcode="AG15" rank="6" />
+                <subcommittee subcomcode="AG16" rank="8" />
+                <subcommittee subcomcode="PW02" rank="13" />
+                <subcommittee subcomcode="PW12" rank="21" />
+                <subcommittee subcomcode="PW13" rank="4" />
+                <subcommittee subcomcode="VR08" rank="2" />
+                <subcommittee subcomcode="VR09" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL13</statedistrict>
+            <member-info>
+                <namelist>Davis, Rodney</namelist>
+                <bioguideID>D000619</bioguideID>
+                <lastname>Davis</lastname>
+                <firstname>Rodney</firstname>
+                <middlename/>
+                <sort-name>DAVIS,RODNEY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Rodney Davis</official-name>
+                <formal-name>Mr. Rodney Davis of Illinois</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>Taylorville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1740</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1313</office-zip-suffix>
+                <phone>(202) 225-2371</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="14" />
+                <committee comcode="HA00" rank="2" />
+                <committee comcode="JP00" rank="1" leadership="Vice Chairman" />
+                <committee comcode="PW00" rank="16" />
+                <subcommittee subcomcode="AG03" rank="6" />
+                <subcommittee subcomcode="AG14" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AG22" rank="5" />
+                <subcommittee subcomcode="PW02" rank="6" />
+                <subcommittee subcomcode="PW05" rank="13" />
+                <subcommittee subcomcode="PW12" rank="14" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL14</statedistrict>
+            <member-info>
+                <namelist>Hultgren, Randy</namelist>
+                <bioguideID>H001059</bioguideID>
+                <lastname>Hultgren</lastname>
+                <firstname>Randy</firstname>
+                <middlename/>
+                <sort-name>HULTGREN,RANDY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Randy Hultgren</official-name>
+                <formal-name>Mr. Hultgren</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Plano</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2455</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1314</office-zip-suffix>
+                <phone>(202) 225-2976</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="12" />
+                <committee comcode="SY00" rank="5" />
+                <subcommittee subcomcode="BA04" rank="8" />
+                <subcommittee subcomcode="BA16" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="SY15" rank="3" />
+                <subcommittee subcomcode="SY20" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL15</statedistrict>
+            <member-info>
+                <namelist>Shimkus, John</namelist>
+                <bioguideID>S000364</bioguideID>
+                <lastname>Shimkus</lastname>
+                <firstname>John</firstname>
+                <middlename/>
+                <sort-name>SHIMKUS,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John Shimkus</official-name>
+                <formal-name>Mr. Shimkus</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>15th</district>
+                <townname>Collinsville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2217</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1315</office-zip-suffix>
+                <phone>(202) 225-5271</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="4" />
+                <subcommittee subcomcode="IF03" rank="4" />
+                <subcommittee subcomcode="IF14" rank="5" />
+                <subcommittee subcomcode="IF16" rank="3" />
+                <subcommittee subcomcode="IF18" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL16</statedistrict>
+            <member-info>
+                <namelist>Kinzinger, Adam</namelist>
+                <bioguideID>K000378</bioguideID>
+                <lastname>Kinzinger</lastname>
+                <firstname>Adam</firstname>
+                <middlename/>
+                <sort-name>KINZINGER,ADAM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Adam Kinzinger</official-name>
+                <formal-name>Mr. Kinzinger</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>16th</district>
+                <townname>Channahon</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2245</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1316</office-zip-suffix>
+                <phone>(202) 225-3635</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="18" />
+                <committee comcode="IF00" rank="16" />
+                <subcommittee subcomcode="FA05" rank="7" />
+                <subcommittee subcomcode="FA13" rank="7" />
+                <subcommittee subcomcode="IF03" rank="9" />
+                <subcommittee subcomcode="IF16" rank="8" />
+                <subcommittee subcomcode="IF17" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL17</statedistrict>
+            <member-info>
+                <namelist>Bustos, Cheri</namelist>
+                <bioguideID>B001286</bioguideID>
+                <lastname>Bustos</lastname>
+                <firstname>Cheri</firstname>
+                <middlename/>
+                <sort-name>BUSTOS,CHERI</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Cheri Bustos</official-name>
+                <formal-name>Mrs. Bustos</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>17th</district>
+                <townname>Moline</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1009</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1317</office-zip-suffix>
+                <phone>(202) 225-5905</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="11" />
+                <committee comcode="PW00" rank="20" />
+                <subcommittee subcomcode="AG16" rank="3" />
+                <subcommittee subcomcode="AG29" rank="3" />
+                <subcommittee subcomcode="PW02" rank="11" />
+                <subcommittee subcomcode="PW05" rank="5" />
+                <subcommittee subcomcode="PW12" rank="20" />
+                <subcommittee subcomcode="PW14" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IL18</statedistrict>
+            <member-info>
+                <namelist>LaHood, Darin</namelist>
+                <bioguideID>L000585</bioguideID>
+                <lastname>LaHood</lastname>
+                <firstname>Darin</firstname>
+                <middlename/>
+                <sort-name>LAHOOD,DARIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Darin LaHood</official-name>
+                <formal-name>Mr. LaHood</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IL">
+                    <state-fullname>Illinois</state-fullname>
+                </state>
+                <district>18th</district>
+                <townname>Peoria</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1424</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1318</office-zip-suffix>
+                <phone>(202) 225-6201</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="EC00" rank="5" />
+                <committee comcode="II00" rank="19" />
+                <committee comcode="SY00" rank="16" />
+                <subcommittee subcomcode="II06" rank="12" />
+                <subcommittee subcomcode="II10" rank="8" />
+                <subcommittee subcomcode="II24" rank="6" />
+                <subcommittee subcomcode="SY15" rank="5" />
+                <subcommittee subcomcode="SY20" rank="9" />
+                <subcommittee subcomcode="SY21" rank="1" leadership="Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN01</statedistrict>
+            <member-info>
+                <namelist>Visclosky, Peter</namelist>
+                <bioguideID>V000108</bioguideID>
+                <lastname>Visclosky</lastname>
+                <firstname>Peter</firstname>
+                <middlename>J.</middlename>
+                <sort-name>VISCLOSKY,PETER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Peter J. Visclosky</official-name>
+                <formal-name>Mr. Visclosky</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Merrillville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2328</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1401</office-zip-suffix>
+                <phone>(202) 225-2461</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="3" />
+                <subcommittee subcomcode="AP02" rank="1" />
+                <subcommittee subcomcode="AP10" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN02</statedistrict>
+            <member-info>
+                <namelist>Walorski, Jackie</namelist>
+                <bioguideID>W000813</bioguideID>
+                <lastname>Walorski</lastname>
+                <firstname>Jackie</firstname>
+                <middlename/>
+                <sort-name>WALORSKI,JACKIE</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jackie Walorski</official-name>
+                <formal-name>Mrs. Walorski</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Elkhart</townname>
+                <office-building>CHOB</office-building>
+                <office-room>419</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1402</office-zip-suffix>
+                <phone>(202) 225-3915</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="22" />
+                <subcommittee subcomcode="WM03" rank="3" />
+                <subcommittee subcomcode="WM06" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN03</statedistrict>
+            <member-info>
+                <namelist>Banks, Jim</namelist>
+                <bioguideID>B001299</bioguideID>
+                <lastname>Banks</lastname>
+                <firstname>Jim</firstname>
+                <middlename/>
+                <sort-name>BANKS,JIM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Jim Banks</official-name>
+                <formal-name>Mr. Banks of Indiana</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Columbia City</townname>
+                <office-building>CHOB</office-building>
+                <office-room>509</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1403</office-zip-suffix>
+                <phone>(202) 225-4436</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="33" />
+                <committee comcode="SY00" rank="18" />
+                <committee comcode="VR00" rank="13" />
+                <subcommittee subcomcode="AS06" rank="4" />
+                <subcommittee subcomcode="AS25" rank="10" />
+                <subcommittee subcomcode="SY15" rank="8" />
+                <subcommittee subcomcode="SY16" rank="11" />
+                <subcommittee subcomcode="SY18" rank="9" leadership="Vice Chair" />
+                <subcommittee subcomcode="VR09" rank="5" />
+                <subcommittee subcomcode="VR10" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN04</statedistrict>
+            <member-info>
+                <namelist>Rokita, Todd</namelist>
+                <bioguideID>R000592</bioguideID>
+                <lastname>Rokita</lastname>
+                <firstname>Todd</firstname>
+                <middlename/>
+                <sort-name>ROKITA,TODD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Todd Rokita</official-name>
+                <formal-name>Mr. Rokita</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Brownsburg</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2439</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1404</office-zip-suffix>
+                <phone>(202) 225-5037</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="5" />
+                <committee comcode="ED00" rank="8" />
+                <committee comcode="PW00" rank="19" />
+                <subcommittee subcomcode="ED02" rank="4" />
+                <subcommittee subcomcode="ED14" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="PW02" rank="9" />
+                <subcommittee subcomcode="PW05" rank="16" />
+                <subcommittee subcomcode="PW14" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN05</statedistrict>
+            <member-info>
+                <namelist>Brooks, Susan</namelist>
+                <bioguideID>B001284</bioguideID>
+                <lastname>Brooks</lastname>
+                <firstname>Susan</firstname>
+                <middlename>W.</middlename>
+                <sort-name>BROOKS,SUSAN</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Susan W. Brooks</official-name>
+                <formal-name>Mrs. Brooks of Indiana</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Carmel</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1030</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1405</office-zip-suffix>
+                <phone>(202) 225-2276</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="23" />
+                <committee comcode="SO00" rank="1" leadership="Chairwoman" />
+                <subcommittee subcomcode="IF02" rank="5" />
+                <subcommittee subcomcode="IF14" rank="14" />
+                <subcommittee subcomcode="IF16" rank="13" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN06</statedistrict>
+            <member-info>
+                <namelist>Messer, Luke</namelist>
+                <bioguideID>M001189</bioguideID>
+                <lastname>Messer</lastname>
+                <firstname>Luke</firstname>
+                <middlename/>
+                <sort-name>MESSER,LUKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Luke Messer</official-name>
+                <formal-name>Mr. Messer</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Greensburg</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1230</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1406</office-zip-suffix>
+                <phone>(202) 225-3021</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="18" />
+                <committee comcode="ED00" rank="10" />
+                <subcommittee subcomcode="BA01" rank="4" />
+                <subcommittee subcomcode="BA09" rank="6" />
+                <subcommittee subcomcode="BA16" rank="8" />
+                <subcommittee subcomcode="ED13" rank="4" />
+                <subcommittee subcomcode="ED14" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN07</statedistrict>
+            <member-info>
+                <namelist>Carson, André</namelist>
+                <bioguideID>C001072</bioguideID>
+                <lastname>Carson</lastname>
+                <firstname>André</firstname>
+                <middlename/>
+                <sort-name>CARSON,ANDRE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>André Carson</official-name>
+                <formal-name>Mr. Carson of Indiana</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Indianapolis</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2135</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1407</office-zip-suffix>
+                <phone>(202) 225-4011</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IG00" rank="4" />
+                <committee comcode="PW00" rank="14" />
+                <subcommittee subcomcode="IG03" rank="1" />
+                <subcommittee subcomcode="IG04" rank="2" />
+                <subcommittee subcomcode="PW05" rank="4" />
+                <subcommittee subcomcode="PW14" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN08</statedistrict>
+            <member-info>
+                <namelist>Bucshon, Larry</namelist>
+                <bioguideID>B001275</bioguideID>
+                <lastname>Bucshon</lastname>
+                <firstname>Larry</firstname>
+                <middlename/>
+                <sort-name>BUCSHON,LARRY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Larry Bucshon</official-name>
+                <formal-name>Mr. Bucshon</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Newburgh</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1005</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1408</office-zip-suffix>
+                <phone>(202) 225-4636</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="21" />
+                <subcommittee subcomcode="IF03" rank="13" />
+                <subcommittee subcomcode="IF14" rank="13" />
+                <subcommittee subcomcode="IF17" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>IN09</statedistrict>
+            <member-info>
+                <namelist>Hollingsworth, Trey</namelist>
+                <bioguideID>H001074</bioguideID>
+                <lastname>Hollingsworth</lastname>
+                <firstname>Trey</firstname>
+                <middlename/>
+                <sort-name>HOLLINGSWORTH,TREY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Trey Hollingsworth</official-name>
+                <formal-name>Mr. Hollingsworth</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="IN">
+                    <state-fullname>Indiana</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Jeffersonville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1641</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1409</office-zip-suffix>
+                <phone>(202) 225-5315</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="34" />
+                <subcommittee subcomcode="BA09" rank="12" />
+                <subcommittee subcomcode="BA16" rank="16" />
+                <subcommittee subcomcode="BA20" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KS01</statedistrict>
+            <member-info>
+                <namelist>Marshall, Roger</namelist>
+                <bioguideID>M001198</bioguideID>
+                <lastname>Marshall</lastname>
+                <firstname>Roger</firstname>
+                <middlename>W.</middlename>
+                <sort-name>MARSHALL,ROGER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Roger W. Marshall</official-name>
+                <formal-name>Mr. Marshall</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KS">
+                    <state-fullname>Kansas</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Great Bend</townname>
+                <office-building>CHOB</office-building>
+                <office-room>312</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1601</office-zip-suffix>
+                <phone>(202) 225-2715</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="22" />
+                <committee comcode="SM00" rank="13" />
+                <committee comcode="SY00" rank="20" />
+                <subcommittee subcomcode="AG03" rank="10" />
+                <subcommittee subcomcode="AG22" rank="7" />
+                <subcommittee subcomcode="AG29" rank="8" />
+                <subcommittee subcomcode="SM24" rank="4" />
+                <subcommittee subcomcode="SM26" rank="6" />
+                <subcommittee subcomcode="SY15" rank="9" />
+                <subcommittee subcomcode="SY21" rank="6" leadership="Vice Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KS02</statedistrict>
+            <member-info>
+                <namelist>Jenkins, Lynn</namelist>
+                <bioguideID>J000290</bioguideID>
+                <lastname>Jenkins</lastname>
+                <firstname>Lynn</firstname>
+                <middlename/>
+                <sort-name>JENKINS,LYNN</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Lynn Jenkins</official-name>
+                <formal-name>Ms. Jenkins of Kansas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KS">
+                    <state-fullname>Kansas</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Topeka</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1526</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1602</office-zip-suffix>
+                <phone>(202) 225-6601</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="9" />
+                <subcommittee subcomcode="WM02" rank="7" />
+                <subcommittee subcomcode="WM04" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KS03</statedistrict>
+            <member-info>
+                <namelist>Yoder, Kevin</namelist>
+                <bioguideID>Y000063</bioguideID>
+                <lastname>Yoder</lastname>
+                <firstname>Kevin</firstname>
+                <middlename/>
+                <sort-name>YODER,KEVIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kevin Yoder</official-name>
+                <formal-name>Mr. Yoder</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KS">
+                    <state-fullname>Kansas</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Overland Park</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2433</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1603</office-zip-suffix>
+                <phone>(202) 225-2865</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="13" />
+                <committee comcode="JL00" rank="2" />
+                <subcommittee subcomcode="AP01" rank="2" />
+                <subcommittee subcomcode="AP23" rank="2" />
+                <subcommittee subcomcode="AP24" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KS04</statedistrict>
+            <member-info>
+                <namelist>Estes, Ron</namelist>
+                <bioguideID>E000298</bioguideID>
+                <lastname>Estes</lastname>
+                <firstname>Ron</firstname>
+                <middlename/>
+                <sort-name>ESTES,RON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Ron Estes</official-name>
+                <formal-name>Mr. Estes of Kansas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KS">
+                    <state-fullname>Kansas</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Wichita</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2452</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1604</office-zip-suffix>
+                <phone>(202) 225-6216</phone>
+                <elected-date date="20170411">April 11, 2017</elected-date>
+                <sworn-date date="20170425">April 25, 2017</sworn-date>
+                <footnote-ref>0</footnote-ref>
+                <footnote>Elected April 11, 2017, to fill the vacancy due to the resignation of Mike Pompeo, January 23, 2017.</footnote>
+            </member-info>
+            <predecessor-info cause="R">
+                <pred-lastname>Pompeo</pred-lastname>
+                <pred-firstname>Mike</pred-firstname>
+                <pred-middlename/>
+                <pred-official-name>Mike Pompeo</pred-official-name>
+                <pred-formal-name>Mr. Pompeo</pred-formal-name>
+                <pred-memindex>P000602</pred-memindex>
+                <pred-sort-name>POMPEO,MIKE</pred-sort-name>
+                <pred-party>R</pred-party>
+                <pred-vacate-date date="20170123">January 23, 2017</pred-vacate-date>
+                <pred-footnote-ref>0</pred-footnote-ref>
+                <pred-footnote>Vacancy due to the resignation of Mike Pompeo, January 23, 2017.</pred-footnote>
+            </predecessor-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="22" />
+                <committee comcode="SM00" rank="14" />
+                <subcommittee subcomcode="ED02" rank="12" />
+                <subcommittee subcomcode="ED13" rank="13" />
+                <subcommittee subcomcode="SM23" rank="4" />
+                <subcommittee subcomcode="SM24" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KY01</statedistrict>
+            <member-info>
+                <namelist>Comer, James</namelist>
+                <bioguideID>C001108</bioguideID>
+                <lastname>Comer</lastname>
+                <firstname>James</firstname>
+                <middlename/>
+                <sort-name>COMER,JAMES</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>James Comer</official-name>
+                <formal-name>Mr. Comer</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KY">
+                    <state-fullname>Kentucky</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Tompkinsville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1513</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1701</office-zip-suffix>
+                <phone>(202) 225-3115</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="21" />
+                <committee comcode="GO00" rank="23" />
+                <committee comcode="SM00" rank="9" />
+                <subcommittee subcomcode="AG03" rank="9" />
+                <subcommittee subcomcode="AG22" rank="6" />
+                <subcommittee subcomcode="GO06" rank="8" />
+                <subcommittee subcomcode="GO28" rank="5" />
+                <subcommittee subcomcode="SM23" rank="3" />
+                <subcommittee subcomcode="SM25" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KY02</statedistrict>
+            <member-info>
+                <namelist>Guthrie, Brett</namelist>
+                <bioguideID>G000558</bioguideID>
+                <lastname>Guthrie</lastname>
+                <firstname>Brett</firstname>
+                <middlename/>
+                <sort-name>GUTHRIE,BRETT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Brett Guthrie</official-name>
+                <formal-name>Mr. Guthrie</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KY">
+                    <state-fullname>Kentucky</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Bowling Green</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2434</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1702</office-zip-suffix>
+                <phone>(202) 225-3501</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="7" />
+                <committee comcode="IF00" rank="13" />
+                <subcommittee subcomcode="ED13" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="IF14" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="IF16" rank="6" />
+                <subcommittee subcomcode="IF17" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KY03</statedistrict>
+            <member-info>
+                <namelist>Yarmuth, John</namelist>
+                <bioguideID>Y000062</bioguideID>
+                <lastname>Yarmuth</lastname>
+                <firstname>John</firstname>
+                <middlename>A.</middlename>
+                <sort-name>YARMUTH,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John A. Yarmuth</official-name>
+                <formal-name>Mr. Yarmuth</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="KY">
+                    <state-fullname>Kentucky</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Louisville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>131</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1703</office-zip-suffix>
+                <phone>(202) 225-5401</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KY04</statedistrict>
+            <member-info>
+                <namelist>Massie, Thomas</namelist>
+                <bioguideID>M001184</bioguideID>
+                <lastname>Massie</lastname>
+                <firstname>Thomas</firstname>
+                <middlename/>
+                <sort-name>MASSIE,THOMAS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Thomas Massie</official-name>
+                <formal-name>Mr. Massie</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KY">
+                    <state-fullname>Kentucky</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Garrison</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2453</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1704</office-zip-suffix>
+                <phone>(202) 225-3465</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="12" />
+                <committee comcode="PW00" rank="13" />
+                <committee comcode="SY00" rank="7" />
+                <subcommittee subcomcode="GO24" rank="5" />
+                <subcommittee subcomcode="GO29" rank="6" />
+                <subcommittee subcomcode="PW02" rank="5" />
+                <subcommittee subcomcode="PW05" rank="10" />
+                <subcommittee subcomcode="PW12" rank="11" />
+                <subcommittee subcomcode="SY20" rank="6" />
+                <subcommittee subcomcode="SY21" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KY05</statedistrict>
+            <member-info>
+                <namelist>Rogers, Harold</namelist>
+                <bioguideID>R000395</bioguideID>
+                <lastname>Rogers</lastname>
+                <firstname>Harold</firstname>
+                <middlename/>
+                <sort-name>ROGERS,HAROLD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Harold Rogers</official-name>
+                <formal-name>Mr. Rogers of Kentucky</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KY">
+                    <state-fullname>Kentucky</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Somerset</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2406</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1705</office-zip-suffix>
+                <phone>(202) 225-4601</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="2" />
+                <subcommittee subcomcode="AP02" rank="2" />
+                <subcommittee subcomcode="AP04" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AP19" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>KY06</statedistrict>
+            <member-info>
+                <namelist>Barr, Andy</namelist>
+                <bioguideID>B001282</bioguideID>
+                <lastname>Barr</lastname>
+                <firstname>Andy</firstname>
+                <middlename/>
+                <sort-name>BARR,ANDY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Andy Barr</official-name>
+                <formal-name>Mr. Barr</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="KY">
+                    <state-fullname>Kentucky</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Lexington</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1427</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1706</office-zip-suffix>
+                <phone>(202) 225-4706</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="16" />
+                <subcommittee subcomcode="BA15" rank="8" />
+                <subcommittee subcomcode="BA20" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>LA01</statedistrict>
+            <member-info>
+                <namelist>Scalise, Steve</namelist>
+                <bioguideID>S001176</bioguideID>
+                <lastname>Scalise</lastname>
+                <firstname>Steve</firstname>
+                <middlename/>
+                <sort-name>SCALISE,STEVE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steve Scalise</official-name>
+                <formal-name>Mr. Scalise</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="LA">
+                    <state-fullname>Louisiana</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Jefferson</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2338</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1801</office-zip-suffix>
+                <phone>(202) 225-3015</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="8" />
+                <subcommittee subcomcode="IF16" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>LA02</statedistrict>
+            <member-info>
+                <namelist>Richmond, Cedric</namelist>
+                <bioguideID>R000588</bioguideID>
+                <lastname>Richmond</lastname>
+                <firstname>Cedric</firstname>
+                <middlename>L.</middlename>
+                <sort-name>RICHMOND,CEDRIC</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Cedric L. Richmond</official-name>
+                <formal-name>Mr. Richmond</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="LA">
+                    <state-fullname>Louisiana</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>New Orleans</townname>
+                <office-building>CHOB</office-building>
+                <office-room>420</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1802</office-zip-suffix>
+                <phone>(202) 225-6636</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="4" />
+                <committee comcode="JU00" rank="10" />
+                <subcommittee subcomcode="HM08" rank="1" />
+                <subcommittee subcomcode="HM11" rank="2" />
+                <subcommittee subcomcode="JU03" rank="6" />
+                <subcommittee subcomcode="JU08" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>LA03</statedistrict>
+            <member-info>
+                <namelist>Higgins, Clay</namelist>
+                <bioguideID>H001077</bioguideID>
+                <lastname>Higgins</lastname>
+                <firstname>Clay</firstname>
+                <middlename/>
+                <sort-name>HIGGINS,CLAY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Clay Higgins</official-name>
+                <formal-name>Mr. Higgins of Louisiana</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="LA">
+                    <state-fullname>Louisiana</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Lafayette</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1711</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1803</office-zip-suffix>
+                <phone>(202) 225-2031</phone>
+                <elected-date date="20161210">December 10, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="15" />
+                <committee comcode="SY00" rank="22" />
+                <committee comcode="VR00" rank="11" />
+                <subcommittee subcomcode="HM07" rank="4" />
+                <subcommittee subcomcode="HM08" rank="5" />
+                <subcommittee subcomcode="HM09" rank="5" />
+                <subcommittee subcomcode="SY16" rank="14" />
+                <subcommittee subcomcode="SY18" rank="10" />
+                <subcommittee subcomcode="SY21" rank="7" />
+                <subcommittee subcomcode="VR03" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>LA04</statedistrict>
+            <member-info>
+                <namelist>Johnson, Mike</namelist>
+                <bioguideID>J000299</bioguideID>
+                <lastname>Johnson</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>JOHNSON,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Mike Johnson</official-name>
+                <formal-name>Mr. Johnson of Louisiana</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="LA">
+                    <state-fullname>Louisiana</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Benton</townname>
+                <office-building>CHOB</office-building>
+                <office-room>327</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1804</office-zip-suffix>
+                <phone>(202) 225-2777</phone>
+                <elected-date date="20161210">December 10, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="24" />
+                <committee comcode="JU00" rank="22" />
+                <subcommittee subcomcode="II13" rank="11" />
+                <subcommittee subcomcode="II15" rank="5" />
+                <subcommittee subcomcode="JU01" rank="7" />
+                <subcommittee subcomcode="JU08" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>LA05</statedistrict>
+            <member-info>
+                <namelist>Abraham, Ralph</namelist>
+                <bioguideID>A000374</bioguideID>
+                <lastname>Abraham</lastname>
+                <firstname>Ralph</firstname>
+                <middlename>Lee</middlename>
+                <sort-name>ABRAHAM,RALPH</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ralph Lee Abraham</official-name>
+                <formal-name>Mr. Abraham</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="LA">
+                    <state-fullname>Louisiana</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Alto</townname>
+                <office-building>CHOB</office-building>
+                <office-room>417</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1805</office-zip-suffix>
+                <phone>(202) 225-8490</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="19" />
+                <committee comcode="AS00" rank="28" />
+                <committee comcode="SY00" rank="15" />
+                <subcommittee subcomcode="AG15" rank="7" />
+                <subcommittee subcomcode="AG16" rank="9" />
+                <subcommittee subcomcode="AS02" rank="7" />
+                <subcommittee subcomcode="AS26" rank="4" />
+                <subcommittee subcomcode="AS28" rank="11" />
+                <subcommittee subcomcode="SY15" rank="6" leadership="Vice Chair" />
+                <subcommittee subcomcode="SY16" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>LA06</statedistrict>
+            <member-info>
+                <namelist>Graves, Garret</namelist>
+                <bioguideID>G000577</bioguideID>
+                <lastname>Graves</lastname>
+                <firstname>Garret</firstname>
+                <middlename/>
+                <sort-name>GRAVES,GARRET</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Garret Graves</official-name>
+                <formal-name>Mr. Graves of Louisiana</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="LA">
+                    <state-fullname>Louisiana</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Baton Rouge</townname>
+                <office-building>CHOB</office-building>
+                <office-room>430</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1806</office-zip-suffix>
+                <phone>(202) 225-3901</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="16" />
+                <committee comcode="PW00" rank="22" />
+                <subcommittee subcomcode="II06" rank="10" />
+                <subcommittee subcomcode="II13" rank="7" />
+                <subcommittee subcomcode="PW02" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="PW07" rank="4" />
+                <subcommittee subcomcode="PW12" rank="18" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA01</statedistrict>
+            <member-info>
+                <namelist>Neal, Richard</namelist>
+                <bioguideID>N000015</bioguideID>
+                <lastname>Neal</lastname>
+                <firstname>Richard</firstname>
+                <middlename>E.</middlename>
+                <sort-name>NEAL,RICHARD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Richard E. Neal</official-name>
+                <formal-name>Mr. Neal</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Springfield</townname>
+                <office-building>CHOB</office-building>
+                <office-room>341</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2101</office-zip-suffix>
+                <phone>(202) 225-5601</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IT00" rank="4" />
+                <committee comcode="WM00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA02</statedistrict>
+            <member-info>
+                <namelist>McGovern, James</namelist>
+                <bioguideID>M000312</bioguideID>
+                <lastname>McGovern</lastname>
+                <firstname>James</firstname>
+                <middlename>P.</middlename>
+                <sort-name>MCGOVERN,JAMES</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>James P. McGovern</official-name>
+                <formal-name>Mr. McGovern</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Worcester</townname>
+                <office-building>CHOB</office-building>
+                <office-room>438</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2102</office-zip-suffix>
+                <phone>(202) 225-6101</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="6" />
+                <committee comcode="RU00" rank="2" />
+                <subcommittee subcomcode="AG03" rank="1" />
+                <subcommittee subcomcode="AG14" rank="5" />
+                <subcommittee subcomcode="RU04" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA03</statedistrict>
+            <member-info>
+                <namelist>Tsongas, Niki</namelist>
+                <bioguideID>T000465</bioguideID>
+                <lastname>Tsongas</lastname>
+                <firstname>Niki</firstname>
+                <middlename/>
+                <sort-name>TSONGAS,NIKI</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Niki Tsongas</official-name>
+                <formal-name>Ms. Tsongas</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Lowell</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1714</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2103</office-zip-suffix>
+                <phone>(202) 225-3411</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="9" />
+                <committee comcode="II00" rank="6" />
+                <subcommittee subcomcode="AS02" rank="3" />
+                <subcommittee subcomcode="AS25" rank="1" />
+                <subcommittee subcomcode="II06" rank="4" />
+                <subcommittee subcomcode="II10" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA04</statedistrict>
+            <member-info>
+                <namelist>Kennedy, Joseph</namelist>
+                <bioguideID>K000379</bioguideID>
+                <lastname>Kennedy</lastname>
+                <firstname>Joseph</firstname>
+                <middlename>P.</middlename>
+                <sort-name>KENNEDY,JOSEPH</sort-name>
+                <suffix>III</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Joseph P. Kennedy III</official-name>
+                <formal-name>Mr. Kennedy</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Newton</townname>
+                <office-building>CHOB</office-building>
+                <office-room>434</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2104</office-zip-suffix>
+                <phone>(202) 225-5931</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="20" />
+                <subcommittee subcomcode="IF03" rank="12" />
+                <subcommittee subcomcode="IF14" rank="10" />
+                <subcommittee subcomcode="IF17" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA05</statedistrict>
+            <member-info>
+                <namelist>Clark, Katherine</namelist>
+                <bioguideID>C001101</bioguideID>
+                <lastname>Clark</lastname>
+                <firstname>Katherine</firstname>
+                <middlename>M.</middlename>
+                <sort-name>CLARK,KATHERINE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Katherine M. Clark</official-name>
+                <formal-name>Ms. Clark of Massachusetts</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Melrose</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1415</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2105</office-zip-suffix>
+                <phone>(202) 225-2836</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="21" />
+                <subcommittee subcomcode="AP07" rank="5" />
+                <subcommittee subcomcode="AP20" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA06</statedistrict>
+            <member-info>
+                <namelist>Moulton, Seth</namelist>
+                <bioguideID>M001196</bioguideID>
+                <lastname>Moulton</lastname>
+                <firstname>Seth</firstname>
+                <middlename/>
+                <sort-name>MOULTON,SETH</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Seth Moulton</official-name>
+                <formal-name>Mr. Moulton</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Salem</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1408</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2106</office-zip-suffix>
+                <phone>(202) 225-8020</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="17" />
+                <committee comcode="BU00" rank="4" />
+                <subcommittee subcomcode="AS06" rank="1" />
+                <subcommittee subcomcode="AS28" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA07</statedistrict>
+            <member-info>
+                <namelist>Capuano, Michael</namelist>
+                <bioguideID>C001037</bioguideID>
+                <lastname>Capuano</lastname>
+                <firstname>Michael</firstname>
+                <middlename>E.</middlename>
+                <sort-name>CAPUANO,MICHAEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Michael E. Capuano</official-name>
+                <formal-name>Mr. Capuano</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Somerville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1414</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2107</office-zip-suffix>
+                <phone>(202) 225-5111</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="6" />
+                <committee comcode="PW00" rank="7" />
+                <subcommittee subcomcode="BA04" rank="3" />
+                <subcommittee subcomcode="BA09" rank="5" />
+                <subcommittee subcomcode="BA15" rank="8" />
+                <subcommittee subcomcode="PW05" rank="12" />
+                <subcommittee subcomcode="PW12" rank="15" />
+                <subcommittee subcomcode="PW13" rank="5" />
+                <subcommittee subcomcode="PW14" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA08</statedistrict>
+            <member-info>
+                <namelist>Lynch, Stephen</namelist>
+                <bioguideID>L000562</bioguideID>
+                <lastname>Lynch</lastname>
+                <firstname>Stephen</firstname>
+                <middlename>F.</middlename>
+                <sort-name>LYNCH,STEPHEN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Stephen F. Lynch</official-name>
+                <formal-name>Mr. Lynch</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>South Boston</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2268</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2108</office-zip-suffix>
+                <phone>(202) 225-8273</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="8" />
+                <committee comcode="GO00" rank="5" />
+                <subcommittee subcomcode="BA01" rank="11" />
+                <subcommittee subcomcode="BA16" rank="3" />
+                <subcommittee subcomcode="GO06" rank="1" />
+                <subcommittee subcomcode="GO25" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MA09</statedistrict>
+            <member-info>
+                <namelist>Keating, William</namelist>
+                <bioguideID>K000375</bioguideID>
+                <lastname>Keating</lastname>
+                <firstname>William</firstname>
+                <middlename>R.</middlename>
+                <sort-name>KEATING,WILLIAM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>William R. Keating</official-name>
+                <formal-name>Mr. Keating</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MA">
+                    <state-fullname>Massachusetts</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Bourne</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2351</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2109</office-zip-suffix>
+                <phone>(202) 225-3111</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="8" />
+                <committee comcode="HM00" rank="5" />
+                <subcommittee subcomcode="FA14" rank="4" />
+                <subcommittee subcomcode="FA18" rank="1" />
+                <subcommittee subcomcode="HM05" rank="3" />
+                <subcommittee subcomcode="HM07" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MD01</statedistrict>
+            <member-info>
+                <namelist>Harris, Andy</namelist>
+                <bioguideID>H001052</bioguideID>
+                <lastname>Harris</lastname>
+                <firstname>Andy</firstname>
+                <middlename/>
+                <sort-name>HARRIS,ANDY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Andy Harris</official-name>
+                <formal-name>Mr. Harris</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MD">
+                    <state-fullname>Maryland</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Cockeysville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1533</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2001</office-zip-suffix>
+                <phone>(202) 225-5311</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="21" />
+                <subcommittee subcomcode="AP01" rank="5" />
+                <subcommittee subcomcode="AP07" rank="5" />
+                <subcommittee subcomcode="AP15" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MD02</statedistrict>
+            <member-info>
+                <namelist>Ruppersberger, C.</namelist>
+                <bioguideID>R000576</bioguideID>
+                <lastname>Ruppersberger</lastname>
+                <firstname>C.</firstname>
+                <middlename>A. Dutch</middlename>
+                <sort-name>RUPPERSBERGER,C.</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>C. A. Dutch Ruppersberger</official-name>
+                <formal-name>Mr. Ruppersberger</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MD">
+                    <state-fullname>Maryland</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Cockeysville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2416</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2002</office-zip-suffix>
+                <phone>(202) 225-3061</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="12" />
+                <subcommittee subcomcode="AP02" rank="4" />
+                <subcommittee subcomcode="AP04" rank="3" />
+                <subcommittee subcomcode="AP15" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MD03</statedistrict>
+            <member-info>
+                <namelist>Sarbanes, John</namelist>
+                <bioguideID>S001168</bioguideID>
+                <lastname>Sarbanes</lastname>
+                <firstname>John</firstname>
+                <middlename>P.</middlename>
+                <sort-name>SARBANES,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John P. Sarbanes</official-name>
+                <formal-name>Mr. Sarbanes</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MD">
+                    <state-fullname>Maryland</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Baltimore</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2444</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2003</office-zip-suffix>
+                <phone>(202) 225-4016</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="18" />
+                <committee comcode="IF00" rank="12" />
+                <subcommittee subcomcode="GO06" rank="5" />
+                <subcommittee subcomcode="IF03" rank="7" />
+                <subcommittee subcomcode="IF14" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MD04</statedistrict>
+            <member-info>
+                <namelist>Brown, Anthony</namelist>
+                <bioguideID>B001304</bioguideID>
+                <lastname>Brown</lastname>
+                <firstname>Anthony</firstname>
+                <middlename>G.</middlename>
+                <sort-name>BROWN,ANTHONY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Anthony G. Brown</official-name>
+                <formal-name>Mr. Brown of Maryland</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MD">
+                    <state-fullname>Maryland</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Mitchellville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1505</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2004</office-zip-suffix>
+                <phone>(202) 225-8699</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="23" />
+                <committee comcode="II00" rank="17" />
+                <committee comcode="SO00" rank="4" />
+                <subcommittee subcomcode="AS03" rank="7" />
+                <subcommittee subcomcode="AS25" rank="8" />
+                <subcommittee subcomcode="II06" rank="2" />
+                <subcommittee subcomcode="II10" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MD05</statedistrict>
+            <member-info>
+                <namelist>Hoyer, Steny</namelist>
+                <bioguideID>H000874</bioguideID>
+                <lastname>Hoyer</lastname>
+                <firstname>Steny</firstname>
+                <middlename>H.</middlename>
+                <sort-name>HOYER,STENY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steny H. Hoyer</official-name>
+                <formal-name>Mr. Hoyer</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MD">
+                    <state-fullname>Maryland</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Mechanicsville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1705</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2005</office-zip-suffix>
+                <phone>(202) 225-4131</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MD06</statedistrict>
+            <member-info>
+                <namelist>Delaney, John</namelist>
+                <bioguideID>D000620</bioguideID>
+                <lastname>Delaney</lastname>
+                <firstname>John</firstname>
+                <middlename>K.</middlename>
+                <sort-name>DELANEY,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John K. Delaney</official-name>
+                <formal-name>Mr. Delaney</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MD">
+                    <state-fullname>Maryland</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Potomac</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1632</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2006</office-zip-suffix>
+                <phone>(202) 225-2721</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="18" />
+                <committee comcode="EC00" rank="8" />
+                <subcommittee subcomcode="BA01" rank="6" />
+                <subcommittee subcomcode="BA04" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MD07</statedistrict>
+            <member-info>
+                <namelist>Cummings, Elijah</namelist>
+                <bioguideID>C000984</bioguideID>
+                <lastname>Cummings</lastname>
+                <firstname>Elijah</firstname>
+                <middlename>E.</middlename>
+                <sort-name>CUMMINGS,ELIJAH</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Elijah E. Cummings</official-name>
+                <formal-name>Mr. Cummings</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MD">
+                    <state-fullname>Maryland</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Baltimore</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2163</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2007</office-zip-suffix>
+                <phone>(202) 225-4741</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="1" />
+                <committee comcode="PW00" rank="5" />
+                <subcommittee subcomcode="PW07" rank="2" />
+                <subcommittee subcomcode="PW14" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MD08</statedistrict>
+            <member-info>
+                <namelist>Raskin, Jamie</namelist>
+                <bioguideID>R000606</bioguideID>
+                <lastname>Raskin</lastname>
+                <firstname>Jamie</firstname>
+                <middlename/>
+                <sort-name>RASKIN,JAMIE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Jamie Raskin</official-name>
+                <formal-name>Mr. Raskin</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MD">
+                    <state-fullname>Maryland</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Takoma Park</townname>
+                <office-building>CHOB</office-building>
+                <office-room>431</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2008</office-zip-suffix>
+                <phone>(202) 225-5341</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="14" />
+                <committee comcode="HA00" rank="3" />
+                <committee comcode="JP00" rank="5" />
+                <committee comcode="JU00" rank="15" />
+                <subcommittee subcomcode="GO25" rank="2" />
+                <subcommittee subcomcode="GO28" rank="2" />
+                <subcommittee subcomcode="JU05" rank="4" />
+                <subcommittee subcomcode="JU10" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>ME01</statedistrict>
+            <member-info>
+                <namelist>Pingree, Chellie</namelist>
+                <bioguideID>P000597</bioguideID>
+                <lastname>Pingree</lastname>
+                <firstname>Chellie</firstname>
+                <middlename/>
+                <sort-name>PINGREE,CHELLIE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Chellie Pingree</official-name>
+                <formal-name>Ms. Pingree</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="ME">
+                    <state-fullname>Maine</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>North Haven</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2162</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1901</office-zip-suffix>
+                <phone>(202) 225-6116</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="15" />
+                <subcommittee subcomcode="AP01" rank="3" />
+                <subcommittee subcomcode="AP06" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>ME02</statedistrict>
+            <member-info>
+                <namelist>Poliquin, Bruce</namelist>
+                <bioguideID>P000611</bioguideID>
+                <lastname>Poliquin</lastname>
+                <firstname>Bruce</firstname>
+                <middlename/>
+                <sort-name>POLIQUIN,BRUCE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bruce Poliquin</official-name>
+                <formal-name>Mr. Poliquin</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="ME">
+                    <state-fullname>Maine</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Oakland</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1208</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>1902</office-zip-suffix>
+                <phone>(202) 225-6306</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="21" />
+                <committee comcode="VR00" rank="7" />
+                <subcommittee subcomcode="BA01" rank="7" />
+                <subcommittee subcomcode="BA16" rank="9" />
+                <subcommittee subcomcode="VR08" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI01</statedistrict>
+            <member-info>
+                <namelist>Bergman, Jack</namelist>
+                <bioguideID>B001301</bioguideID>
+                <lastname>Bergman</lastname>
+                <firstname>Jack</firstname>
+                <middlename/>
+                <sort-name>BERGMAN,JACK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Jack Bergman</official-name>
+                <formal-name>Mr. Bergman</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Watersmeet</townname>
+                <office-building>CHOB</office-building>
+                <office-room>414</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2201</office-zip-suffix>
+                <phone>(202) 225-4735</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="17" />
+                <committee comcode="II00" rank="22" />
+                <committee comcode="VR00" rank="12" />
+                <subcommittee subcomcode="II10" rank="11" />
+                <subcommittee subcomcode="II15" rank="4" />
+                <subcommittee subcomcode="II24" rank="7" />
+                <subcommittee subcomcode="VR08" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="VR09" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI02</statedistrict>
+            <member-info>
+                <namelist>Huizenga, Bill</namelist>
+                <bioguideID>H001058</bioguideID>
+                <lastname>Huizenga</lastname>
+                <firstname>Bill</firstname>
+                <middlename/>
+                <sort-name>HUIZENGA,BILL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bill Huizenga</official-name>
+                <formal-name>Mr. Huizenga</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Zeeland</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2232</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2202</office-zip-suffix>
+                <phone>(202) 225-4401</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="9" />
+                <subcommittee subcomcode="BA16" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="BA20" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI03</statedistrict>
+            <member-info>
+                <namelist>Amash, Justin</namelist>
+                <bioguideID>A000367</bioguideID>
+                <lastname>Amash</lastname>
+                <firstname>Justin</firstname>
+                <middlename/>
+                <sort-name>AMASH,JUSTIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Justin Amash</official-name>
+                <formal-name>Mr. Amash</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Cascade Township</townname>
+                <office-building>CHOB</office-building>
+                <office-room>114</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2203</office-zip-suffix>
+                <phone>(202) 225-3831</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="6" />
+                <subcommittee subcomcode="GO06" rank="4" />
+                <subcommittee subcomcode="GO25" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI04</statedistrict>
+            <member-info>
+                <namelist>Moolenaar, John</namelist>
+                <bioguideID>M001194</bioguideID>
+                <lastname>Moolenaar</lastname>
+                <firstname>John</firstname>
+                <middlename>R.</middlename>
+                <sort-name>MOOLENAAR,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John R. Moolenaar</official-name>
+                <formal-name>Mr. Moolenaar</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Midland</townname>
+                <office-building>CHOB</office-building>
+                <office-room>117</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2204</office-zip-suffix>
+                <phone>(202) 225-3561</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="29" />
+                <subcommittee subcomcode="AP07" rank="8" />
+                <subcommittee subcomcode="AP23" rank="7" />
+                <subcommittee subcomcode="AP24" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI05</statedistrict>
+            <member-info>
+                <namelist>Kildee, Daniel</namelist>
+                <bioguideID>K000380</bioguideID>
+                <lastname>Kildee</lastname>
+                <firstname>Daniel</firstname>
+                <middlename>T.</middlename>
+                <sort-name>KILDEE,DANIEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Daniel T. Kildee</official-name>
+                <formal-name>Mr. Kildee</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Flushing</townname>
+                <office-building>CHOB</office-building>
+                <office-room>227</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2205</office-zip-suffix>
+                <phone>(202) 225-3611</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="17" />
+                <subcommittee subcomcode="BA01" rank="5" />
+                <subcommittee subcomcode="BA04" rank="7" />
+                <subcommittee subcomcode="BA20" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI06</statedistrict>
+            <member-info>
+                <namelist>Upton, Fred</namelist>
+                <bioguideID>U000031</bioguideID>
+                <lastname>Upton</lastname>
+                <firstname>Fred</firstname>
+                <middlename/>
+                <sort-name>UPTON,FRED</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Fred Upton</official-name>
+                <formal-name>Mr. Upton</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>St. Joseph</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2183</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2206</office-zip-suffix>
+                <phone>(202) 225-3761</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="3" />
+                <subcommittee subcomcode="IF03" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="IF14" rank="4" />
+                <subcommittee subcomcode="IF17" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI07</statedistrict>
+            <member-info>
+                <namelist>Walberg, Tim</namelist>
+                <bioguideID>W000798</bioguideID>
+                <lastname>Walberg</lastname>
+                <firstname>Tim</firstname>
+                <middlename/>
+                <sort-name>WALBERG,TIM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tim Walberg</official-name>
+                <formal-name>Mr. Walberg</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Tipton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2436</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2207</office-zip-suffix>
+                <phone>(202) 225-6276</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="6" />
+                <committee comcode="IF00" rank="28" />
+                <subcommittee subcomcode="ED02" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="IF02" rank="7" />
+                <subcommittee subcomcode="IF03" rank="18" />
+                <subcommittee subcomcode="IF18" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI08</statedistrict>
+            <member-info>
+                <namelist>Bishop, Mike</namelist>
+                <bioguideID>B001293</bioguideID>
+                <lastname>Bishop</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>BISHOP,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mike Bishop</official-name>
+                <formal-name>Mr. Bishop of Michigan</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Rochester</townname>
+                <office-building>CHOB</office-building>
+                <office-room>428</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2208</office-zip-suffix>
+                <phone>(202) 225-4872</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="24" />
+                <subcommittee subcomcode="WM03" rank="5" />
+                <subcommittee subcomcode="WM06" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI09</statedistrict>
+            <member-info>
+                <namelist>Levin, Sander</namelist>
+                <bioguideID>L000263</bioguideID>
+                <lastname>Levin</lastname>
+                <firstname>Sander</firstname>
+                <middlename>M.</middlename>
+                <sort-name>LEVIN,SANDER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Sander M. Levin</official-name>
+                <formal-name>Mr. Levin</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Royal Oak</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1236</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2209</office-zip-suffix>
+                <phone>(202) 225-4961</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="2" />
+                <subcommittee subcomcode="WM02" rank="1" />
+                <subcommittee subcomcode="WM04" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI10</statedistrict>
+            <member-info>
+                <namelist>Mitchell, Paul</namelist>
+                <bioguideID>M001201</bioguideID>
+                <lastname>Mitchell</lastname>
+                <firstname>Paul</firstname>
+                <middlename/>
+                <sort-name>MITCHELL,PAUL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Paul Mitchell</official-name>
+                <formal-name>Mr. Mitchell</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Dryden</townname>
+                <office-building>CHOB</office-building>
+                <office-room>211</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2210</office-zip-suffix>
+                <phone>(202) 225-2106</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="18" />
+                <committee comcode="GO00" rank="24" />
+                <committee comcode="PW00" rank="30" />
+                <subcommittee subcomcode="ED02" rank="9" />
+                <subcommittee subcomcode="ED13" rank="10" />
+                <subcommittee subcomcode="GO25" rank="2" leadership="Vice Chair" />
+                <subcommittee subcomcode="GO27" rank="8" />
+                <subcommittee subcomcode="PW05" rank="20" />
+                <subcommittee subcomcode="PW12" rank="25" />
+                <subcommittee subcomcode="PW14" rank="16" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI11</statedistrict>
+            <member-info>
+                <namelist>Trott, David</namelist>
+                <bioguideID>T000475</bioguideID>
+                <lastname>Trott</lastname>
+                <firstname>David</firstname>
+                <middlename>A.</middlename>
+                <sort-name>TROTT,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David A. Trott</official-name>
+                <formal-name>Mr. Trott</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Birmingham</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1722</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2211</office-zip-suffix>
+                <phone>(202) 225-8171</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="26" />
+                <subcommittee subcomcode="BA04" rank="11" />
+                <subcommittee subcomcode="BA09" rank="8" />
+                <subcommittee subcomcode="BA15" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI12</statedistrict>
+            <member-info>
+                <namelist>Dingell, Debbie</namelist>
+                <bioguideID>D000624</bioguideID>
+                <lastname>Dingell</lastname>
+                <firstname>Debbie</firstname>
+                <middlename/>
+                <sort-name>DINGELL,DEBBIE</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Debbie Dingell</official-name>
+                <formal-name>Mrs. Dingell</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Dearborn</townname>
+                <office-building>CHOB</office-building>
+                <office-room>116</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2212</office-zip-suffix>
+                <phone>(202) 225-4071</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="24" />
+                <subcommittee subcomcode="IF16" rank="6" />
+                <subcommittee subcomcode="IF17" rank="5" />
+                <subcommittee subcomcode="IF18" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI13</statedistrict>
+            <member-info>
+                <namelist>Conyers, John</namelist>
+                <bioguideID>C000714</bioguideID>
+                <lastname>Conyers</lastname>
+                <firstname>John</firstname>
+                <middlename/>
+                <sort-name>CONYERS,JOHN</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John Conyers, Jr.</official-name>
+                <formal-name>Mr. Conyers</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>Detroit</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2426</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2213</office-zip-suffix>
+                <phone>(202) 225-5126</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="JU00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MI14</statedistrict>
+            <member-info>
+                <namelist>Lawrence, Brenda</namelist>
+                <bioguideID>L000581</bioguideID>
+                <lastname>Lawrence</lastname>
+                <firstname>Brenda</firstname>
+                <middlename>L.</middlename>
+                <sort-name>LAWRENCE,BRENDA</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Brenda L. Lawrence</official-name>
+                <formal-name>Mrs. Lawrence</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MI">
+                    <state-fullname>Michigan</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Southfield</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1213</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2214</office-zip-suffix>
+                <phone>(202) 225-5802</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="9" />
+                <committee comcode="PW00" rank="26" />
+                <subcommittee subcomcode="GO24" rank="5" />
+                <subcommittee subcomcode="PW02" rank="13" />
+                <subcommittee subcomcode="PW05" rank="11" />
+                <subcommittee subcomcode="PW12" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MN01</statedistrict>
+            <member-info>
+                <namelist>Walz, Timothy</namelist>
+                <bioguideID>W000799</bioguideID>
+                <lastname>Walz</lastname>
+                <firstname>Timothy</firstname>
+                <middlename>J.</middlename>
+                <sort-name>WALZ,TIMOTHY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Timothy J. Walz</official-name>
+                <formal-name>Mr. Walz</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MN">
+                    <state-fullname>Minnesota</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Mankato</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2313</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2301</office-zip-suffix>
+                <phone>(202) 225-2472</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="4" />
+                <committee comcode="VR00" rank="1" />
+                <subcommittee subcomcode="AG15" rank="2" />
+                <subcommittee subcomcode="AG16" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MN02</statedistrict>
+            <member-info>
+                <namelist>Lewis, Jason</namelist>
+                <bioguideID>L000587</bioguideID>
+                <lastname>Lewis</lastname>
+                <firstname>Jason</firstname>
+                <middlename/>
+                <sort-name>LEWIS,JASON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Jason Lewis</official-name>
+                <formal-name>Mr. Lewis of Minnesota</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MN">
+                    <state-fullname>Minnesota</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Woodbury</townname>
+                <office-building>CHOB</office-building>
+                <office-room>418</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2302</office-zip-suffix>
+                <phone>(202) 225-2271</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="16" />
+                <committee comcode="ED00" rank="16" />
+                <committee comcode="PW00" rank="34" />
+                <subcommittee subcomcode="ED02" rank="7" />
+                <subcommittee subcomcode="ED13" rank="9" />
+                <subcommittee subcomcode="PW05" rank="21" />
+                <subcommittee subcomcode="PW07" rank="8" />
+                <subcommittee subcomcode="PW14" rank="18" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MN03</statedistrict>
+            <member-info>
+                <namelist>Paulsen, Erik</namelist>
+                <bioguideID>P000594</bioguideID>
+                <lastname>Paulsen</lastname>
+                <firstname>Erik</firstname>
+                <middlename/>
+                <sort-name>PAULSEN,ERIK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Erik Paulsen</official-name>
+                <formal-name>Mr. Paulsen</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MN">
+                    <state-fullname>Minnesota</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Eden Prairie</townname>
+                <office-building>CHOB</office-building>
+                <office-room>127</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2303</office-zip-suffix>
+                <phone>(202) 225-2871</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="EC00" rank="2" />
+                <committee comcode="WM00" rank="10" />
+                <subcommittee subcomcode="WM02" rank="10" />
+                <subcommittee subcomcode="WM04" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MN04</statedistrict>
+            <member-info>
+                <namelist>McCollum, Betty</namelist>
+                <bioguideID>M001143</bioguideID>
+                <lastname>McCollum</lastname>
+                <firstname>Betty</firstname>
+                <middlename/>
+                <sort-name>MCCOLLUM,BETTY</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Betty McCollum</official-name>
+                <formal-name>Ms. McCollum</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MN">
+                    <state-fullname>Minnesota</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>St. Paul</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2256</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2304</office-zip-suffix>
+                <phone>(202) 225-6631</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="10" />
+                <subcommittee subcomcode="AP02" rank="2" />
+                <subcommittee subcomcode="AP06" rank="1" />
+                <subcommittee subcomcode="AP24" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MN05</statedistrict>
+            <member-info>
+                <namelist>Ellison, Keith</namelist>
+                <bioguideID>E000288</bioguideID>
+                <lastname>Ellison</lastname>
+                <firstname>Keith</firstname>
+                <middlename/>
+                <sort-name>ELLISON,KEITH</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Keith Ellison</official-name>
+                <formal-name>Mr. Ellison</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MN">
+                    <state-fullname>Minnesota</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Minneapolis</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2263</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2305</office-zip-suffix>
+                <phone>(202) 225-4755</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="13" />
+                <subcommittee subcomcode="BA09" rank="2" />
+                <subcommittee subcomcode="BA15" rank="7" />
+                <subcommittee subcomcode="BA16" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MN06</statedistrict>
+            <member-info>
+                <namelist>Emmer, Tom</namelist>
+                <bioguideID>E000294</bioguideID>
+                <lastname>Emmer</lastname>
+                <firstname>Tom</firstname>
+                <middlename/>
+                <sort-name>EMMER,TOM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tom Emmer</official-name>
+                <formal-name>Mr. Emmer</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MN">
+                    <state-fullname>Minnesota</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Delano</townname>
+                <office-building>CHOB</office-building>
+                <office-room>315</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2306</office-zip-suffix>
+                <phone>(202) 225-2331</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="24" />
+                <subcommittee subcomcode="BA01" rank="10" />
+                <subcommittee subcomcode="BA16" rank="11" />
+                <subcommittee subcomcode="BA20" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MN07</statedistrict>
+            <member-info>
+                <namelist>Peterson, Collin</namelist>
+                <bioguideID>P000258</bioguideID>
+                <lastname>Peterson</lastname>
+                <firstname>Collin</firstname>
+                <middlename>C.</middlename>
+                <sort-name>PETERSON,COLLIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Collin C. Peterson</official-name>
+                <formal-name>Mr. Peterson</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MN">
+                    <state-fullname>Minnesota</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Detroit Lakes</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2204</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2307</office-zip-suffix>
+                <phone>(202) 225-2165</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MN08</statedistrict>
+            <member-info>
+                <namelist>Nolan, Richard</namelist>
+                <bioguideID>N000127</bioguideID>
+                <lastname>Nolan</lastname>
+                <firstname>Richard</firstname>
+                <middlename>M.</middlename>
+                <sort-name>NOLAN,RICHARD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Richard M. Nolan</official-name>
+                <formal-name>Mr. Nolan</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MN">
+                    <state-fullname>Minnesota</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Crosby</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2366</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2308</office-zip-suffix>
+                <phone>(202) 225-6211</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="10" />
+                <committee comcode="PW00" rank="15" />
+                <subcommittee subcomcode="AG15" rank="4" />
+                <subcommittee subcomcode="AG16" rank="1" />
+                <subcommittee subcomcode="PW05" rank="16" />
+                <subcommittee subcomcode="PW12" rank="5" />
+                <subcommittee subcomcode="PW14" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MO01</statedistrict>
+            <member-info>
+                <namelist>Clay, Wm.</namelist>
+                <bioguideID>C001049</bioguideID>
+                <lastname>Clay</lastname>
+                <firstname>Wm.</firstname>
+                <middlename>Lacy</middlename>
+                <sort-name>CLAY,WM.</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Wm. Lacy Clay</official-name>
+                <formal-name>Mr. Clay</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MO">
+                    <state-fullname>Missouri</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>St. Louis</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2428</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2501</office-zip-suffix>
+                <phone>(202) 225-2406</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="7" />
+                <committee comcode="GO00" rank="4" />
+                <committee comcode="II00" rank="18" />
+                <subcommittee subcomcode="BA04" rank="4" />
+                <subcommittee subcomcode="BA15" rank="1" />
+                <subcommittee subcomcode="GO24" rank="4" />
+                <subcommittee subcomcode="II15" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MO02</statedistrict>
+            <member-info>
+                <namelist>Wagner, Ann</namelist>
+                <bioguideID>W000812</bioguideID>
+                <lastname>Wagner</lastname>
+                <firstname>Ann</firstname>
+                <middlename/>
+                <sort-name>WAGNER,ANN</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ann Wagner</official-name>
+                <formal-name>Mrs. Wagner</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MO">
+                    <state-fullname>Missouri</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Ballwin</townname>
+                <office-building>CHOB</office-building>
+                <office-room>435</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2502</office-zip-suffix>
+                <phone>(202) 225-1621</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="15" />
+                <committee comcode="FA00" rank="22" />
+                <subcommittee subcomcode="BA09" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="BA16" rank="7" />
+                <subcommittee subcomcode="FA05" rank="8" />
+                <subcommittee subcomcode="FA13" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MO03</statedistrict>
+            <member-info>
+                <namelist>Luetkemeyer, Blaine</namelist>
+                <bioguideID>L000569</bioguideID>
+                <lastname>Luetkemeyer</lastname>
+                <firstname>Blaine</firstname>
+                <middlename/>
+                <sort-name>LUETKEMEYER,BLAINE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Blaine Luetkemeyer</official-name>
+                <formal-name>Mr. Luetkemeyer</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MO">
+                    <state-fullname>Missouri</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>St. Elizabeth</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2230</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2503</office-zip-suffix>
+                <phone>(202) 225-2956</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="8" />
+                <committee comcode="SM00" rank="3" />
+                <subcommittee subcomcode="BA04" rank="6" />
+                <subcommittee subcomcode="BA15" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="SM25" rank="3" />
+                <subcommittee subcomcode="SM26" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MO04</statedistrict>
+            <member-info>
+                <namelist>Hartzler, Vicky</namelist>
+                <bioguideID>H001053</bioguideID>
+                <lastname>Hartzler</lastname>
+                <firstname>Vicky</firstname>
+                <middlename/>
+                <sort-name>HARTZLER,VICKY</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Vicky Hartzler</official-name>
+                <formal-name>Mrs. Hartzler</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MO">
+                    <state-fullname>Missouri</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Harrisonville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2235</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2504</office-zip-suffix>
+                <phone>(202) 225-2876</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="11" />
+                <committee comcode="AS00" rank="15" />
+                <subcommittee subcomcode="AG03" rank="5" />
+                <subcommittee subcomcode="AG29" rank="5" />
+                <subcommittee subcomcode="AS03" rank="6" />
+                <subcommittee subcomcode="AS06" rank="1" leadership="Chairwoman" />
+                <subcommittee subcomcode="AS28" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MO05</statedistrict>
+            <member-info>
+                <namelist>Cleaver, Emanuel</namelist>
+                <bioguideID>C001061</bioguideID>
+                <lastname>Cleaver</lastname>
+                <firstname>Emanuel</firstname>
+                <middlename/>
+                <sort-name>CLEAVER,EMANUEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Emanuel Cleaver</official-name>
+                <formal-name>Mr. Cleaver</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MO">
+                    <state-fullname>Missouri</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Kansas City</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2335</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2505</office-zip-suffix>
+                <phone>(202) 225-4535</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="11" />
+                <subcommittee subcomcode="BA04" rank="1" />
+                <subcommittee subcomcode="BA09" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MO06</statedistrict>
+            <member-info>
+                <namelist>Graves, Sam</namelist>
+                <bioguideID>G000546</bioguideID>
+                <lastname>Graves</lastname>
+                <firstname>Sam</firstname>
+                <middlename/>
+                <sort-name>GRAVES,SAM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Sam Graves</official-name>
+                <formal-name>Mr. Graves of Missouri</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MO">
+                    <state-fullname>Missouri</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Tarkio</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1135</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2506</office-zip-suffix>
+                <phone>(202) 225-7041</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="22" />
+                <committee comcode="PW00" rank="5" />
+                <subcommittee subcomcode="AS25" rank="4" />
+                <subcommittee subcomcode="AS29" rank="10" />
+                <subcommittee subcomcode="PW05" rank="4" />
+                <subcommittee subcomcode="PW12" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="PW14" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MO07</statedistrict>
+            <member-info>
+                <namelist>Long, Billy</namelist>
+                <bioguideID>L000576</bioguideID>
+                <lastname>Long</lastname>
+                <firstname>Billy</firstname>
+                <middlename/>
+                <sort-name>LONG,BILLY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Billy Long</official-name>
+                <formal-name>Mr. Long</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MO">
+                    <state-fullname>Missouri</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Springfield</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2454</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2507</office-zip-suffix>
+                <phone>(202) 225-6536</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="20" />
+                <subcommittee subcomcode="IF03" rank="12" />
+                <subcommittee subcomcode="IF14" rank="12" />
+                <subcommittee subcomcode="IF16" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MO08</statedistrict>
+            <member-info>
+                <namelist>Smith, Jason</namelist>
+                <bioguideID>S001195</bioguideID>
+                <lastname>Smith</lastname>
+                <firstname>Jason</firstname>
+                <middlename/>
+                <sort-name>SMITH,JASON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jason Smith</official-name>
+                <formal-name>Mr. Smith of Missouri</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MO">
+                    <state-fullname>Missouri</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Salem</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1118</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2508</office-zip-suffix>
+                <phone>(202) 225-4404</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="15" />
+                <committee comcode="WM00" rank="19" />
+                <subcommittee subcomcode="WM01" rank="7" />
+                <subcommittee subcomcode="WM03" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MP00</statedistrict>
+            <member-info>
+                <namelist>Sablan, Gregorio</namelist>
+                <bioguideID>S001177</bioguideID>
+                <lastname>Sablan</lastname>
+                <firstname>Gregorio</firstname>
+                <middlename>Kilili Camacho</middlename>
+                <sort-name>SABLAN,GREGORIO</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Gregorio Kilili Camacho Sablan</official-name>
+                <formal-name>Mr. Sablan</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MP">
+                    <state-fullname>Northern Mariana Islands</state-fullname>
+                </state>
+                <district>Delegate</district>
+                <townname>Saipan</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2411</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>5201</office-zip-suffix>
+                <phone>(202) 225-2646</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="7" />
+                <committee comcode="II00" rank="5" />
+                <committee comcode="VR00" rank="8" />
+                <subcommittee subcomcode="ED02" rank="1" />
+                <subcommittee subcomcode="ED13" rank="7" />
+                <subcommittee subcomcode="II13" rank="8" />
+                <subcommittee subcomcode="II24" rank="3" />
+                <subcommittee subcomcode="VR08" rank="4" />
+                <subcommittee subcomcode="VR09" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MS01</statedistrict>
+            <member-info>
+                <namelist>Kelly, Trent</namelist>
+                <bioguideID>K000388</bioguideID>
+                <lastname>Kelly</lastname>
+                <firstname>Trent</firstname>
+                <middlename/>
+                <sort-name>KELLY,TRENT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Trent Kelly</official-name>
+                <formal-name>Mr. Kelly of Mississippi</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MS">
+                    <state-fullname>Mississippi</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Saltillo</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1721</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2401</office-zip-suffix>
+                <phone>(202) 225-4306</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="20" />
+                <committee comcode="AS00" rank="29" />
+                <committee comcode="SM00" rank="7" />
+                <subcommittee subcomcode="AG15" rank="8" />
+                <subcommittee subcomcode="AG29" rank="7" />
+                <subcommittee subcomcode="AS02" rank="8" />
+                <subcommittee subcomcode="AS03" rank="10" />
+                <subcommittee subcomcode="AS25" rank="7" />
+                <subcommittee subcomcode="SM24" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="SM27" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MS02</statedistrict>
+            <member-info>
+                <namelist>Thompson, Bennie</namelist>
+                <bioguideID>T000193</bioguideID>
+                <lastname>Thompson</lastname>
+                <firstname>Bennie</firstname>
+                <middlename>G.</middlename>
+                <sort-name>THOMPSON,BENNIE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bennie G. Thompson</official-name>
+                <formal-name>Mr. Thompson of Mississippi</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="MS">
+                    <state-fullname>Mississippi</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Bolton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2466</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2402</office-zip-suffix>
+                <phone>(202) 225-5876</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MS03</statedistrict>
+            <member-info>
+                <namelist>Harper, Gregg</namelist>
+                <bioguideID>H001045</bioguideID>
+                <lastname>Harper</lastname>
+                <firstname>Gregg</firstname>
+                <middlename/>
+                <sort-name>HARPER,GREGG</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Gregg Harper</official-name>
+                <formal-name>Mr. Harper</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MS">
+                    <state-fullname>Mississippi</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Pearl</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2227</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2403</office-zip-suffix>
+                <phone>(202) 225-5031</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HA00" rank="1" leadership="Chairman" />
+                <committee comcode="IF00" rank="11" />
+                <committee comcode="JL00" rank="1" leadership="Chairman" />
+                <committee comcode="JP00" rank="2" />
+                <subcommittee subcomcode="IF03" rank="7" />
+                <subcommittee subcomcode="IF17" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="IF18" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MS04</statedistrict>
+            <member-info>
+                <namelist>Palazzo, Steven</namelist>
+                <bioguideID>P000601</bioguideID>
+                <lastname>Palazzo</lastname>
+                <firstname>Steven</firstname>
+                <middlename>M.</middlename>
+                <sort-name>PALAZZO,STEVEN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steven M. Palazzo</official-name>
+                <formal-name>Mr. Palazzo</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="MS">
+                    <state-fullname>Mississippi</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Biloxi</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2349</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2404</office-zip-suffix>
+                <phone>(202) 225-5772</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="27" />
+                <subcommittee subcomcode="AP01" rank="7" />
+                <subcommittee subcomcode="AP15" rank="5" leadership="Vice Chair" />
+                <subcommittee subcomcode="AP19" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>MT00</statedistrict>
+            <member-info>
+                <namelist/>
+                <bioguideID/>
+                <lastname/>
+                <firstname/>
+                <middlename/>
+                <sort-name/>
+                <suffix/>
+                <courtesy/>
+                <prior-congress>0</prior-congress>
+                <official-name/>
+                <formal-name/>
+                <party/>
+                <caucus/>
+                <state postal-code="MT">
+                    <state-fullname>Montana</state-fullname>
+                </state>
+                <district>At Large</district>
+                <townname/>
+                <office-building>LHOB</office-building>
+                <office-room>1419</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2600</office-zip-suffix>
+                <phone>(202) 225-3211</phone>
+                <elected-date date="" />
+                <sworn-date date="" />
+                <footnote-ref>0</footnote-ref>
+                <footnote>Vacancy due to the resignation of Ryan K. Zinke, March 1, 2017.</footnote>
+            </member-info>
+            <predecessor-info cause="R">
+                <pred-lastname>Zinke</pred-lastname>
+                <pred-firstname>Ryan</pred-firstname>
+                <pred-middlename>K.</pred-middlename>
+                <pred-official-name>Ryan K. Zinke</pred-official-name>
+                <pred-formal-name>Mr. Zinke</pred-formal-name>
+                <pred-memindex>Z000018</pred-memindex>
+                <pred-sort-name>ZINKE,RYAN</pred-sort-name>
+                <pred-party>R</pred-party>
+                <pred-vacate-date date="20170301">March 1, 2017</pred-vacate-date>
+                <pred-footnote-ref>0</pred-footnote-ref>
+                <pred-footnote>Vacancy due to the resignation of Ryan Zinke, March 1, 2017.</pred-footnote>
+            </predecessor-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC01</statedistrict>
+            <member-info>
+                <namelist>Butterfield, G.</namelist>
+                <bioguideID>B001251</bioguideID>
+                <lastname>Butterfield</lastname>
+                <firstname>G.</firstname>
+                <middlename>K.</middlename>
+                <sort-name>BUTTERFIELD,G.</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>G. K. Butterfield</official-name>
+                <formal-name>Mr. Butterfield</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Wilson</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2080</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3301</office-zip-suffix>
+                <phone>(202) 225-3101</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="9" />
+                <subcommittee subcomcode="IF03" rank="13" />
+                <subcommittee subcomcode="IF14" rank="4" />
+                <subcommittee subcomcode="IF16" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC02</statedistrict>
+            <member-info>
+                <namelist>Holding, George</namelist>
+                <bioguideID>H001065</bioguideID>
+                <lastname>Holding</lastname>
+                <firstname>George</firstname>
+                <middlename/>
+                <sort-name>HOLDING,GEORGE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>George Holding</official-name>
+                <formal-name>Mr. Holding</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Raleigh</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1110</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3302</office-zip-suffix>
+                <phone>(202) 225-3032</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="18" />
+                <subcommittee subcomcode="WM04" rank="9" />
+                <subcommittee subcomcode="WM05" rank="7" />
+                <subcommittee subcomcode="WM06" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC03</statedistrict>
+            <member-info>
+                <namelist>Jones, Walter</namelist>
+                <bioguideID>J000255</bioguideID>
+                <lastname>Jones</lastname>
+                <firstname>Walter</firstname>
+                <middlename>B.</middlename>
+                <sort-name>JONES,WALTER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Walter B. Jones</official-name>
+                <formal-name>Mr. Jones</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Farmville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2333</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3303</office-zip-suffix>
+                <phone>(202) 225-3415</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="2" />
+                <subcommittee subcomcode="AS02" rank="2" />
+                <subcommittee subcomcode="AS25" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC04</statedistrict>
+            <member-info>
+                <namelist>Price, David</namelist>
+                <bioguideID>P000523</bioguideID>
+                <lastname>Price</lastname>
+                <firstname>David</firstname>
+                <middlename>E.</middlename>
+                <sort-name>PRICE,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David E. Price</official-name>
+                <formal-name>Mr. Price of North Carolina</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Chapel Hill</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2108</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3304</office-zip-suffix>
+                <phone>(202) 225-1784</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="6" />
+                <subcommittee subcomcode="AP04" rank="5" />
+                <subcommittee subcomcode="AP15" rank="3" />
+                <subcommittee subcomcode="AP20" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC05</statedistrict>
+            <member-info>
+                <namelist>Foxx, Virginia</namelist>
+                <bioguideID>F000450</bioguideID>
+                <lastname>Foxx</lastname>
+                <firstname>Virginia</firstname>
+                <middlename/>
+                <sort-name>FOXX,VIRGINIA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Virginia Foxx</official-name>
+                <formal-name>Ms. Foxx</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Banner Elk</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2262</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3305</office-zip-suffix>
+                <phone>(202) 225-2071</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="1" leadership="Chairwoman" />
+                <committee comcode="GO00" rank="11" />
+                <subcommittee subcomcode="GO06" rank="6" />
+                <subcommittee subcomcode="GO29" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC06</statedistrict>
+            <member-info>
+                <namelist>Walker, Mark</namelist>
+                <bioguideID>W000819</bioguideID>
+                <lastname>Walker</lastname>
+                <firstname>Mark</firstname>
+                <middlename/>
+                <sort-name>WALKER,MARK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mark Walker</official-name>
+                <formal-name>Mr. Walker</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Greensboro</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1305</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3306</office-zip-suffix>
+                <phone>(202) 225-3065</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="16" />
+                <committee comcode="HA00" rank="4" />
+                <committee comcode="JP00" rank="3" />
+                <subcommittee subcomcode="GO27" rank="2" leadership="Vice Chair" />
+                <subcommittee subcomcode="GO29" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC07</statedistrict>
+            <member-info>
+                <namelist>Rouzer, David</namelist>
+                <bioguideID>R000603</bioguideID>
+                <lastname>Rouzer</lastname>
+                <firstname>David</firstname>
+                <middlename/>
+                <sort-name>ROUZER,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David Rouzer</official-name>
+                <formal-name>Mr. Rouzer</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>McGee's Crossroad</townname>
+                <office-building>CHOB</office-building>
+                <office-room>424</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3307</office-zip-suffix>
+                <phone>(202) 225-2731</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="18" />
+                <committee comcode="II00" rank="21" />
+                <committee comcode="PW00" rank="24" />
+                <subcommittee subcomcode="AG03" rank="8" />
+                <subcommittee subcomcode="AG14" rank="5" />
+                <subcommittee subcomcode="AG29" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="II10" rank="10" />
+                <subcommittee subcomcode="II13" rank="10" />
+                <subcommittee subcomcode="PW02" rank="12" />
+                <subcommittee subcomcode="PW07" rank="5" />
+                <subcommittee subcomcode="PW12" rank="20" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC08</statedistrict>
+            <member-info>
+                <namelist>Hudson, Richard</namelist>
+                <bioguideID>H001067</bioguideID>
+                <lastname>Hudson</lastname>
+                <firstname>Richard</firstname>
+                <middlename/>
+                <sort-name>HUDSON,RICHARD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Richard Hudson</official-name>
+                <formal-name>Mr. Hudson</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Concord</townname>
+                <office-building>CHOB</office-building>
+                <office-room>429</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3308</office-zip-suffix>
+                <phone>(202) 225-3715</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="25" />
+                <subcommittee subcomcode="IF03" rank="16" />
+                <subcommittee subcomcode="IF14" rank="16" />
+                <subcommittee subcomcode="IF18" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC09</statedistrict>
+            <member-info>
+                <namelist>Pittenger, Robert</namelist>
+                <bioguideID>P000606</bioguideID>
+                <lastname>Pittenger</lastname>
+                <firstname>Robert</firstname>
+                <middlename/>
+                <sort-name>PITTENGER,ROBERT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Robert Pittenger</official-name>
+                <formal-name>Mr. Pittenger</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Charlotte</townname>
+                <office-building>CHOB</office-building>
+                <office-room>224</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3309</office-zip-suffix>
+                <phone>(202) 225-1976</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="14" />
+                <subcommittee subcomcode="BA01" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="BA15" rank="7" />
+                <subcommittee subcomcode="BA20" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC10</statedistrict>
+            <member-info>
+                <namelist>McHenry, Patrick</namelist>
+                <bioguideID>M001156</bioguideID>
+                <lastname>McHenry</lastname>
+                <firstname>Patrick</firstname>
+                <middlename>T.</middlename>
+                <sort-name>MCHENRY,PATRICK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Patrick T. McHenry</official-name>
+                <formal-name>Mr. McHenry</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Lake Norman</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2334</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3310</office-zip-suffix>
+                <phone>(202) 225-2576</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="5" />
+                <subcommittee subcomcode="BA09" rank="4" />
+                <subcommittee subcomcode="BA16" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC11</statedistrict>
+            <member-info>
+                <namelist>Meadows, Mark</namelist>
+                <bioguideID>M001187</bioguideID>
+                <lastname>Meadows</lastname>
+                <firstname>Mark</firstname>
+                <middlename/>
+                <sort-name>MEADOWS,MARK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mark Meadows</official-name>
+                <formal-name>Mr. Meadows</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Skyland</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1024</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3311</office-zip-suffix>
+                <phone>(202) 225-6401</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="16" />
+                <committee comcode="GO00" rank="13" />
+                <committee comcode="PW00" rank="14" />
+                <subcommittee subcomcode="FA13" rank="5" />
+                <subcommittee subcomcode="FA16" rank="2" />
+                <subcommittee subcomcode="GO24" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="GO27" rank="6" />
+                <subcommittee subcomcode="PW05" rank="11" />
+                <subcommittee subcomcode="PW12" rank="12" />
+                <subcommittee subcomcode="PW14" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC12</statedistrict>
+            <member-info>
+                <namelist>Adams, Alma</namelist>
+                <bioguideID>A000370</bioguideID>
+                <lastname>Adams</lastname>
+                <firstname>Alma</firstname>
+                <middlename>S.</middlename>
+                <sort-name>ADAMS,ALMA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Alma S. Adams</official-name>
+                <formal-name>Ms. Adams</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Charlotte</townname>
+                <office-building>CHOB</office-building>
+                <office-room>222</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3312</office-zip-suffix>
+                <phone>(202) 225-1510</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="14" />
+                <committee comcode="EC00" rank="9" />
+                <committee comcode="ED00" rank="11" />
+                <committee comcode="SM00" rank="7" />
+                <subcommittee subcomcode="AG03" rank="2" />
+                <subcommittee subcomcode="ED10" rank="3" />
+                <subcommittee subcomcode="ED13" rank="3" />
+                <subcommittee subcomcode="SM24" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NC13</statedistrict>
+            <member-info>
+                <namelist>Budd, Ted</namelist>
+                <bioguideID>B001305</bioguideID>
+                <lastname>Budd</lastname>
+                <firstname>Ted</firstname>
+                <middlename/>
+                <sort-name>BUDD,TED</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Ted Budd</official-name>
+                <formal-name>Mr. Budd</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NC">
+                    <state-fullname>North Carolina</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>Advance</townname>
+                <office-building>CHOB</office-building>
+                <office-room>118</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3313</office-zip-suffix>
+                <phone>(202) 225-4531</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="31" />
+                <subcommittee subcomcode="BA01" rank="13" />
+                <subcommittee subcomcode="BA04" rank="13" />
+                <subcommittee subcomcode="BA16" rank="15" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>ND00</statedistrict>
+            <member-info>
+                <namelist>Cramer, Kevin</namelist>
+                <bioguideID>C001096</bioguideID>
+                <lastname>Cramer</lastname>
+                <firstname>Kevin</firstname>
+                <middlename/>
+                <sort-name>CRAMER,KEVIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kevin Cramer</official-name>
+                <formal-name>Mr. Cramer</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="ND">
+                    <state-fullname>North Dakota</state-fullname>
+                </state>
+                <district>At Large</district>
+                <townname>Bismarck</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1717</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3400</office-zip-suffix>
+                <phone>(202) 225-2611</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="27" />
+                <subcommittee subcomcode="IF03" rank="17" />
+                <subcommittee subcomcode="IF16" rank="15" />
+                <subcommittee subcomcode="IF18" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NE01</statedistrict>
+            <member-info>
+                <namelist>Fortenberry, Jeff</namelist>
+                <bioguideID>F000449</bioguideID>
+                <lastname>Fortenberry</lastname>
+                <firstname>Jeff</firstname>
+                <middlename/>
+                <sort-name>FORTENBERRY,JEFF</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jeff Fortenberry</official-name>
+                <formal-name>Mr. Fortenberry</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NE">
+                    <state-fullname>Nebraska</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Lincoln</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1514</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2701</office-zip-suffix>
+                <phone>(202) 225-4806</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="15" />
+                <subcommittee subcomcode="AP04" rank="6" />
+                <subcommittee subcomcode="AP10" rank="4" />
+                <subcommittee subcomcode="AP18" rank="2" leadership="Vice Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NE02</statedistrict>
+            <member-info>
+                <namelist>Bacon, Don</namelist>
+                <bioguideID>B001298</bioguideID>
+                <lastname>Bacon</lastname>
+                <firstname>Don</firstname>
+                <middlename/>
+                <sort-name>BACON,DON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Don Bacon</official-name>
+                <formal-name>Mr. Bacon</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NE">
+                    <state-fullname>Nebraska</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Papillion</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1516</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2702</office-zip-suffix>
+                <phone>(202) 225-4155</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="23" />
+                <committee comcode="AS00" rank="32" />
+                <committee comcode="SM00" rank="11" />
+                <subcommittee subcomcode="AG14" rank="6" />
+                <subcommittee subcomcode="AG16" rank="10" />
+                <subcommittee subcomcode="AS02" rank="5" />
+                <subcommittee subcomcode="AS25" rank="9" />
+                <subcommittee subcomcode="SM24" rank="3" />
+                <subcommittee subcomcode="SM25" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NE03</statedistrict>
+            <member-info>
+                <namelist>Smith, Adrian</namelist>
+                <bioguideID>S001172</bioguideID>
+                <lastname>Smith</lastname>
+                <firstname>Adrian</firstname>
+                <middlename/>
+                <sort-name>SMITH,ADRIAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Adrian Smith</official-name>
+                <formal-name>Mr. Smith of Nebraska</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NE">
+                    <state-fullname>Nebraska</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Gering</townname>
+                <office-building>CHOB</office-building>
+                <office-room>320</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2703</office-zip-suffix>
+                <phone>(202) 225-6435</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HA00" rank="5" />
+                <committee comcode="WM00" rank="8" />
+                <subcommittee subcomcode="WM02" rank="6" />
+                <subcommittee subcomcode="WM03" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NH01</statedistrict>
+            <member-info>
+                <namelist>Shea-Porter, Carol</namelist>
+                <bioguideID>S001170</bioguideID>
+                <lastname>Shea-Porter</lastname>
+                <firstname>Carol</firstname>
+                <middlename/>
+                <sort-name>SHEAPORTER,CAROL</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>113</prior-congress>
+                <official-name>Carol Shea-Porter</official-name>
+                <formal-name>Ms. Shea-Porter</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NH">
+                    <state-fullname>New Hampshire</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Rochester</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1530</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2901</office-zip-suffix>
+                <phone>(202) 225-5456</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="19" />
+                <committee comcode="ED00" rank="16" />
+                <subcommittee subcomcode="AS02" rank="5" />
+                <subcommittee subcomcode="AS03" rank="4" />
+                <subcommittee subcomcode="ED02" rank="5" />
+                <subcommittee subcomcode="ED10" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NH02</statedistrict>
+            <member-info>
+                <namelist>Kuster, Ann</namelist>
+                <bioguideID>K000382</bioguideID>
+                <lastname>Kuster</lastname>
+                <firstname>Ann</firstname>
+                <middlename>M.</middlename>
+                <sort-name>KUSTER,ANN</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ann M. Kuster</official-name>
+                <formal-name>Ms. Kuster of New Hampshire</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NH">
+                    <state-fullname>New Hampshire</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Hopkinton</townname>
+                <office-building>CHOB</office-building>
+                <office-room>137</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2902</office-zip-suffix>
+                <phone>(202) 225-5206</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="9" />
+                <committee comcode="VR00" rank="4" />
+                <subcommittee subcomcode="AG15" rank="3" />
+                <subcommittee subcomcode="AG22" rank="3" />
+                <subcommittee subcomcode="VR03" rank="3" />
+                <subcommittee subcomcode="VR08" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ01</statedistrict>
+            <member-info>
+                <namelist>Norcross, Donald</namelist>
+                <bioguideID>N000188</bioguideID>
+                <lastname>Norcross</lastname>
+                <firstname>Donald</firstname>
+                <middlename/>
+                <sort-name>NORCROSS,DONALD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Donald Norcross</official-name>
+                <formal-name>Mr. Norcross</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Camden City</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1531</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3001</office-zip-suffix>
+                <phone>(202) 225-6501</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="15" />
+                <committee comcode="ED00" rank="13" />
+                <subcommittee subcomcode="AS28" rank="6" />
+                <subcommittee subcomcode="AS29" rank="6" />
+                <subcommittee subcomcode="ED02" rank="3" />
+                <subcommittee subcomcode="ED10" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ02</statedistrict>
+            <member-info>
+                <namelist>LoBiondo, Frank</namelist>
+                <bioguideID>L000554</bioguideID>
+                <lastname>LoBiondo</lastname>
+                <firstname>Frank</firstname>
+                <middlename>A.</middlename>
+                <sort-name>LOBIONDO,FRANK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Frank A. LoBiondo</official-name>
+                <formal-name>Mr. LoBiondo</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Ventnor</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2427</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3002</office-zip-suffix>
+                <phone>(202) 225-6572</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="4" />
+                <committee comcode="IG00" rank="4" />
+                <committee comcode="PW00" rank="4" />
+                <subcommittee subcomcode="AS25" rank="2" />
+                <subcommittee subcomcode="AS26" rank="7" />
+                <subcommittee subcomcode="IG01" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="IG03" rank="2" />
+                <subcommittee subcomcode="PW05" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="PW07" rank="3" />
+                <subcommittee subcomcode="PW12" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ03</statedistrict>
+            <member-info>
+                <namelist>MacArthur, Thomas</namelist>
+                <bioguideID>M001193</bioguideID>
+                <lastname>MacArthur</lastname>
+                <firstname>Thomas</firstname>
+                <middlename/>
+                <sort-name>MACARTHUR,THOMAS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Thomas MacArthur</official-name>
+                <formal-name>Mr. MacArthur</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Toms River</townname>
+                <office-building>CHOB</office-building>
+                <office-room>506</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3003</office-zip-suffix>
+                <phone>(202) 225-4765</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="29" />
+                <subcommittee subcomcode="BA04" rank="12" />
+                <subcommittee subcomcode="BA16" rank="13" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ04</statedistrict>
+            <member-info>
+                <namelist>Smith, Christopher</namelist>
+                <bioguideID>S000522</bioguideID>
+                <lastname>Smith</lastname>
+                <firstname>Christopher</firstname>
+                <middlename>H.</middlename>
+                <sort-name>SMITH,CHRISTOPHER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Christopher H. Smith</official-name>
+                <formal-name>Mr. Smith of New Jersey</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Hamilton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2373</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3004</office-zip-suffix>
+                <phone>(202) 225-3765</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="2" />
+                <subcommittee subcomcode="FA07" rank="2" />
+                <subcommittee subcomcode="FA16" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ05</statedistrict>
+            <member-info>
+                <namelist>Gottheimer, Josh</namelist>
+                <bioguideID>G000583</bioguideID>
+                <lastname>Gottheimer</lastname>
+                <firstname>Josh</firstname>
+                <middlename/>
+                <sort-name>GOTTHEIMER,JOSH</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Josh Gottheimer</official-name>
+                <formal-name>Mr. Gottheimer</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Wyckoff</townname>
+                <office-building>CHOB</office-building>
+                <office-room>213</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3005</office-zip-suffix>
+                <phone>(202) 225-4465</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="23" />
+                <subcommittee subcomcode="BA01" rank="9" />
+                <subcommittee subcomcode="BA09" rank="7" />
+                <subcommittee subcomcode="BA16" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ06</statedistrict>
+            <member-info>
+                <namelist>Pallone, Frank</namelist>
+                <bioguideID>P000034</bioguideID>
+                <lastname>Pallone</lastname>
+                <firstname>Frank</firstname>
+                <middlename/>
+                <sort-name>PALLONE,FRANK</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Frank Pallone, Jr.</official-name>
+                <formal-name>Mr. Pallone</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Long Branch</townname>
+                <office-building>CHOB</office-building>
+                <office-room>237</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3006</office-zip-suffix>
+                <phone>(202) 225-4671</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ07</statedistrict>
+            <member-info>
+                <namelist>Lance, Leonard</namelist>
+                <bioguideID>L000567</bioguideID>
+                <lastname>Lance</lastname>
+                <firstname>Leonard</firstname>
+                <middlename/>
+                <sort-name>LANCE,LEONARD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Leonard Lance</official-name>
+                <formal-name>Mr. Lance</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Clinton Township</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2352</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3007</office-zip-suffix>
+                <phone>(202) 225-5361</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="12" />
+                <committee comcode="SO00" rank="5" />
+                <subcommittee subcomcode="IF14" rank="9" />
+                <subcommittee subcomcode="IF16" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="IF17" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ08</statedistrict>
+            <member-info>
+                <namelist>Sires, Albio</namelist>
+                <bioguideID>S001165</bioguideID>
+                <lastname>Sires</lastname>
+                <firstname>Albio</firstname>
+                <middlename/>
+                <sort-name>SIRES,ALBIO</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Albio Sires</official-name>
+                <formal-name>Mr. Sires</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>West New York</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2342</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3008</office-zip-suffix>
+                <phone>(202) 225-7919</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="4" />
+                <committee comcode="PW00" rank="11" />
+                <subcommittee subcomcode="FA07" rank="1" />
+                <subcommittee subcomcode="FA14" rank="3" />
+                <subcommittee subcomcode="PW12" rank="4" />
+                <subcommittee subcomcode="PW13" rank="3" />
+                <subcommittee subcomcode="PW14" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ09</statedistrict>
+            <member-info>
+                <namelist>Pascrell, Bill</namelist>
+                <bioguideID>P000096</bioguideID>
+                <lastname>Pascrell</lastname>
+                <firstname>Bill</firstname>
+                <middlename/>
+                <sort-name>PASCRELL,BILL</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bill Pascrell, Jr.</official-name>
+                <formal-name>Mr. Pascrell</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Paterson</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2370</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3009</office-zip-suffix>
+                <phone>(202) 225-5751</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="9" />
+                <subcommittee subcomcode="WM01" rank="2" />
+                <subcommittee subcomcode="WM04" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ10</statedistrict>
+            <member-info>
+                <namelist>Payne, Donald</namelist>
+                <bioguideID>P000604</bioguideID>
+                <lastname>Payne</lastname>
+                <firstname>Donald</firstname>
+                <middlename>M.</middlename>
+                <sort-name>PAYNE,DONALD</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Donald M. Payne, Jr.</official-name>
+                <formal-name>Mr. Payne</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Newark</townname>
+                <office-building>CHOB</office-building>
+                <office-room>132</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3010</office-zip-suffix>
+                <phone>(202) 225-3436</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="6" />
+                <committee comcode="PW00" rank="24" />
+                <subcommittee subcomcode="HM07" rank="3" />
+                <subcommittee subcomcode="HM12" rank="1" />
+                <subcommittee subcomcode="PW05" rank="10" />
+                <subcommittee subcomcode="PW14" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ11</statedistrict>
+            <member-info>
+                <namelist>Frelinghuysen, Rodney</namelist>
+                <bioguideID>F000372</bioguideID>
+                <lastname>Frelinghuysen</lastname>
+                <firstname>Rodney</firstname>
+                <middlename>P.</middlename>
+                <sort-name>FRELINGHUYSEN,RODNEY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Rodney P. Frelinghuysen</official-name>
+                <formal-name>Mr. Frelinghuysen</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Morristown</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2306</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3011</office-zip-suffix>
+                <phone>(202) 225-5034</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="1" leadership="Chairman" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NJ12</statedistrict>
+            <member-info>
+                <namelist>Watson Coleman, Bonnie</namelist>
+                <bioguideID>W000822</bioguideID>
+                <lastname>Watson Coleman</lastname>
+                <firstname>Bonnie</firstname>
+                <middlename/>
+                <sort-name>WATSONCOLEMAN,BONNIE</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bonnie Watson Coleman</official-name>
+                <formal-name>Mrs. Watson Coleman</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NJ">
+                    <state-fullname>New Jersey</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Ewing Township</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1535</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3012</office-zip-suffix>
+                <phone>(202) 225-5801</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="10" />
+                <committee comcode="HM00" rank="8" />
+                <subcommittee subcomcode="GO24" rank="6" />
+                <subcommittee subcomcode="GO27" rank="5" />
+                <subcommittee subcomcode="HM07" rank="1" />
+                <subcommittee subcomcode="HM12" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NM01</statedistrict>
+            <member-info>
+                <namelist>Lujan Grisham, Michelle</namelist>
+                <bioguideID>L000580</bioguideID>
+                <lastname>Lujan Grisham</lastname>
+                <firstname>Michelle</firstname>
+                <middlename/>
+                <sort-name>LUJANGRISHAM,MICHELLE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Michelle Lujan Grisham</official-name>
+                <formal-name>Ms. Michelle Lujan Grisham of New Mexico</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NM">
+                    <state-fullname>New Mexico</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Albuquerque</townname>
+                <office-building>CHOB</office-building>
+                <office-room>214</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3101</office-zip-suffix>
+                <phone>(202) 225-6316</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="8" />
+                <committee comcode="BU00" rank="3" />
+                <subcommittee subcomcode="AG03" rank="5" />
+                <subcommittee subcomcode="AG14" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NM02</statedistrict>
+            <member-info>
+                <namelist>Pearce, Stevan</namelist>
+                <bioguideID>P000588</bioguideID>
+                <lastname>Pearce</lastname>
+                <firstname>Stevan</firstname>
+                <middlename/>
+                <sort-name>PEARCE,STEVAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Stevan Pearce</official-name>
+                <formal-name>Mr. Pearce</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NM">
+                    <state-fullname>New Mexico</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Hobbs</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2432</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3102</office-zip-suffix>
+                <phone>(202) 225-2365</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="6" />
+                <committee comcode="II00" rank="7" />
+                <subcommittee subcomcode="BA01" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="BA04" rank="4" />
+                <subcommittee subcomcode="II06" rank="5" />
+                <subcommittee subcomcode="II10" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NM03</statedistrict>
+            <member-info>
+                <namelist>Luján, Ben</namelist>
+                <bioguideID>L000570</bioguideID>
+                <lastname>Luján</lastname>
+                <firstname>Ben</firstname>
+                <middlename>Ray</middlename>
+                <sort-name>LUJAN,BEN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ben Ray Luján</official-name>
+                <formal-name>Mr. Ben Ray Luján of New Mexico</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NM">
+                    <state-fullname>New Mexico</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Nambé</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2231</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3103</office-zip-suffix>
+                <phone>(202) 225-6190</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="15" />
+                <subcommittee subcomcode="IF14" rank="8" />
+                <subcommittee subcomcode="IF17" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NV01</statedistrict>
+            <member-info>
+                <namelist>Titus, Dina</namelist>
+                <bioguideID>T000468</bioguideID>
+                <lastname>Titus</lastname>
+                <firstname>Dina</firstname>
+                <middlename/>
+                <sort-name>TITUS,DINA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Dina Titus</official-name>
+                <formal-name>Ms. Titus</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NV">
+                    <state-fullname>Nevada</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Las Vegas</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2464</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2801</office-zip-suffix>
+                <phone>(202) 225-5965</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="16" />
+                <committee comcode="PW00" rank="16" />
+                <subcommittee subcomcode="FA05" rank="3" />
+                <subcommittee subcomcode="FA18" rank="4" />
+                <subcommittee subcomcode="PW02" rank="8" />
+                <subcommittee subcomcode="PW05" rank="7" />
+                <subcommittee subcomcode="PW12" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NV02</statedistrict>
+            <member-info>
+                <namelist>Amodei, Mark</namelist>
+                <bioguideID>A000369</bioguideID>
+                <lastname>Amodei</lastname>
+                <firstname>Mark</firstname>
+                <middlename>E.</middlename>
+                <sort-name>AMODEI,MARK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mark E. Amodei</official-name>
+                <formal-name>Mr. Amodei</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NV">
+                    <state-fullname>Nevada</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Carson City</townname>
+                <office-building>CHOB</office-building>
+                <office-room>332</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2802</office-zip-suffix>
+                <phone>(202) 225-6155</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="23" />
+                <subcommittee subcomcode="AP06" rank="6" />
+                <subcommittee subcomcode="AP23" rank="4" />
+                <subcommittee subcomcode="AP24" rank="2" leadership="Vice Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NV03</statedistrict>
+            <member-info>
+                <namelist>Rosen, Jacky</namelist>
+                <bioguideID>R000608</bioguideID>
+                <lastname>Rosen</lastname>
+                <firstname>Jacky</firstname>
+                <middlename/>
+                <sort-name>ROSEN,JACKY</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Jacky Rosen</official-name>
+                <formal-name>Ms. Rosen</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NV">
+                    <state-fullname>Nevada</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Henderson</townname>
+                <office-building>CHOB</office-building>
+                <office-room>413</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2803</office-zip-suffix>
+                <phone>(202) 225-3252</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="20" />
+                <committee comcode="SY00" rank="9" />
+                <subcommittee subcomcode="AS02" rank="6" />
+                <subcommittee subcomcode="AS25" rank="6" />
+                <subcommittee subcomcode="SY15" rank="3" />
+                <subcommittee subcomcode="SY20" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NV04</statedistrict>
+            <member-info>
+                <namelist>Kihuen, Ruben</namelist>
+                <bioguideID>K000390</bioguideID>
+                <lastname>Kihuen</lastname>
+                <firstname>Ruben</firstname>
+                <middlename>J.</middlename>
+                <sort-name>KIHUEN,RUBEN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Ruben J. Kihuen</official-name>
+                <formal-name>Mr. Kihuen</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NV">
+                    <state-fullname>Nevada</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Las Vegas</townname>
+                <office-building>CHOB</office-building>
+                <office-room>313</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>2804</office-zip-suffix>
+                <phone>(202) 225-9894</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="26" />
+                <subcommittee subcomcode="BA01" rank="10" />
+                <subcommittee subcomcode="BA04" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY01</statedistrict>
+            <member-info>
+                <namelist>Zeldin, Lee</namelist>
+                <bioguideID>Z000017</bioguideID>
+                <lastname>Zeldin</lastname>
+                <firstname>Lee</firstname>
+                <middlename>M.</middlename>
+                <sort-name>ZELDIN,LEE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Lee M. Zeldin</official-name>
+                <formal-name>Mr. Zeldin</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Shirley</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1517</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3201</office-zip-suffix>
+                <phone>(202) 225-3826</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="25" />
+                <committee comcode="FA00" rank="19" />
+                <subcommittee subcomcode="BA01" rank="11" />
+                <subcommittee subcomcode="BA04" rank="10" />
+                <subcommittee subcomcode="BA09" rank="7" />
+                <subcommittee subcomcode="FA13" rank="8" />
+                <subcommittee subcomcode="FA18" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY02</statedistrict>
+            <member-info>
+                <namelist>King, Peter</namelist>
+                <bioguideID>K000210</bioguideID>
+                <lastname>King</lastname>
+                <firstname>Peter</firstname>
+                <middlename>T.</middlename>
+                <sort-name>KING,PETER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Peter T. King</official-name>
+                <formal-name>Mr. King of New York</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Seaford</townname>
+                <office-building>CHOB</office-building>
+                <office-room>339</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3202</office-zip-suffix>
+                <phone>(202) 225-7896</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="2" />
+                <committee comcode="HM00" rank="3" />
+                <committee comcode="IG00" rank="3" />
+                <subcommittee subcomcode="BA09" rank="3" />
+                <subcommittee subcomcode="BA16" rank="3" />
+                <subcommittee subcomcode="HM05" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="HM07" rank="2" />
+                <subcommittee subcomcode="IG01" rank="3" />
+                <subcommittee subcomcode="IG03" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY03</statedistrict>
+            <member-info>
+                <namelist>Suozzi, Thomas</namelist>
+                <bioguideID>S001201</bioguideID>
+                <lastname>Suozzi</lastname>
+                <firstname>Thomas</firstname>
+                <middlename>R.</middlename>
+                <sort-name>SUOZZI,THOMAS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Thomas R. Suozzi</official-name>
+                <formal-name>Mr. Suozzi</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Glen Cove</townname>
+                <office-building>CHOB</office-building>
+                <office-room>226</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3203</office-zip-suffix>
+                <phone>(202) 225-3335</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="27" />
+                <committee comcode="FA00" rank="19" />
+                <subcommittee subcomcode="AS06" rank="3" />
+                <subcommittee subcomcode="AS25" rank="10" />
+                <subcommittee subcomcode="FA13" rank="8" />
+                <subcommittee subcomcode="FA16" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY04</statedistrict>
+            <member-info>
+                <namelist>Rice, Kathleen</namelist>
+                <bioguideID>R000602</bioguideID>
+                <lastname>Rice</lastname>
+                <firstname>Kathleen</firstname>
+                <middlename>M.</middlename>
+                <sort-name>RICE,KATHLEEN</sort-name>
+                <suffix/>
+                <courtesy>Miss</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kathleen M. Rice</official-name>
+                <formal-name>Miss Rice of New York</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Garden City</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1508</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3204</office-zip-suffix>
+                <phone>(202) 225-5516</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="9" />
+                <committee comcode="VR00" rank="6" />
+                <subcommittee subcomcode="HM05" rank="1" />
+                <subcommittee subcomcode="HM09" rank="2" />
+                <subcommittee subcomcode="VR08" rank="2" />
+                <subcommittee subcomcode="VR10" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY05</statedistrict>
+            <member-info>
+                <namelist>Meeks, Gregory</namelist>
+                <bioguideID>M001137</bioguideID>
+                <lastname>Meeks</lastname>
+                <firstname>Gregory</firstname>
+                <middlename>W.</middlename>
+                <sort-name>MEEKS,GREGORY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Gregory W. Meeks</official-name>
+                <formal-name>Mr. Meeks</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Queens</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2234</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3205</office-zip-suffix>
+                <phone>(202) 225-3461</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="5" />
+                <committee comcode="FA00" rank="3" />
+                <subcommittee subcomcode="BA15" rank="3" />
+                <subcommittee subcomcode="BA16" rank="8" />
+                <subcommittee subcomcode="BA20" rank="2" />
+                <subcommittee subcomcode="FA07" rank="6" />
+                <subcommittee subcomcode="FA14" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY06</statedistrict>
+            <member-info>
+                <namelist>Meng, Grace</namelist>
+                <bioguideID>M001188</bioguideID>
+                <lastname>Meng</lastname>
+                <firstname>Grace</firstname>
+                <middlename/>
+                <sort-name>MENG,GRACE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Grace Meng</official-name>
+                <formal-name>Ms. Meng</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Queens</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1317</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3206</office-zip-suffix>
+                <phone>(202) 225-2601</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="19" />
+                <subcommittee subcomcode="AP04" rank="4" />
+                <subcommittee subcomcode="AP19" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY07</statedistrict>
+            <member-info>
+                <namelist>Velázquez, Nydia</namelist>
+                <bioguideID>V000081</bioguideID>
+                <lastname>Velázquez</lastname>
+                <firstname>Nydia</firstname>
+                <middlename>M.</middlename>
+                <sort-name>VELAZQUEZ,NYDIA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Nydia M. Velázquez</official-name>
+                <formal-name>Ms. Velázquez</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Brooklyn</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2302</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3207</office-zip-suffix>
+                <phone>(202) 225-2361</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="3" />
+                <committee comcode="SM00" rank="1" />
+                <subcommittee subcomcode="BA04" rank="2" />
+                <subcommittee subcomcode="BA15" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY08</statedistrict>
+            <member-info>
+                <namelist>Jeffries, Hakeem</namelist>
+                <bioguideID>J000294</bioguideID>
+                <lastname>Jeffries</lastname>
+                <firstname>Hakeem</firstname>
+                <middlename>S.</middlename>
+                <sort-name>JEFFRIES,HAKEEM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Hakeem S. Jeffries</official-name>
+                <formal-name>Mr. Jeffries</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Brooklyn</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1607</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3208</office-zip-suffix>
+                <phone>(202) 225-5936</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="5" />
+                <committee comcode="JU00" rank="11" />
+                <subcommittee subcomcode="JU03" rank="7" />
+                <subcommittee subcomcode="JU08" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY09</statedistrict>
+            <member-info>
+                <namelist>Clarke, Yvette</namelist>
+                <bioguideID>C001067</bioguideID>
+                <lastname>Clarke</lastname>
+                <firstname>Yvette</firstname>
+                <middlename>D.</middlename>
+                <sort-name>CLARKE,YVETTE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Yvette D. Clarke</official-name>
+                <formal-name>Ms. Clarke of New York</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Brooklyn</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2058</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3209</office-zip-suffix>
+                <phone>(202) 225-6231</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="17" />
+                <committee comcode="SM00" rank="5" />
+                <committee comcode="SO00" rank="2" />
+                <subcommittee subcomcode="IF02" rank="5" />
+                <subcommittee subcomcode="IF16" rank="3" />
+                <subcommittee subcomcode="IF17" rank="3" />
+                <subcommittee subcomcode="SM23" rank="2" />
+                <subcommittee subcomcode="SM27" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY10</statedistrict>
+            <member-info>
+                <namelist>Nadler, Jerrold</namelist>
+                <bioguideID>N000002</bioguideID>
+                <lastname>Nadler</lastname>
+                <firstname>Jerrold</firstname>
+                <middlename/>
+                <sort-name>NADLER,JERROLD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jerrold Nadler</official-name>
+                <formal-name>Mr. Nadler</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>New York</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2109</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3210</office-zip-suffix>
+                <phone>(202) 225-5635</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="JU00" rank="2" />
+                <committee comcode="PW00" rank="3" />
+                <subcommittee subcomcode="JU03" rank="1" />
+                <subcommittee subcomcode="JU10" rank="3" />
+                <subcommittee subcomcode="PW12" rank="2" />
+                <subcommittee subcomcode="PW14" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY11</statedistrict>
+            <member-info>
+                <namelist>Donovan, Daniel</namelist>
+                <bioguideID>D000625</bioguideID>
+                <lastname>Donovan</lastname>
+                <firstname>Daniel</firstname>
+                <middlename>M.</middlename>
+                <sort-name>DONOVAN,DANIEL</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Daniel M. Donovan, Jr.</official-name>
+                <formal-name>Mr. Donovan</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Staten Island</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1541</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3211</office-zip-suffix>
+                <phone>(202) 225-3371</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="20" />
+                <committee comcode="HM00" rank="13" />
+                <subcommittee subcomcode="FA13" rank="9" />
+                <subcommittee subcomcode="FA16" rank="3" />
+                <subcommittee subcomcode="HM08" rank="3" />
+                <subcommittee subcomcode="HM12" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY12</statedistrict>
+            <member-info>
+                <namelist>Maloney, Carolyn</namelist>
+                <bioguideID>M000087</bioguideID>
+                <lastname>Maloney</lastname>
+                <firstname>Carolyn</firstname>
+                <middlename>B.</middlename>
+                <sort-name>MALONEY,CAROLYN</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Carolyn B. Maloney</official-name>
+                <formal-name>Mrs. Carolyn B. Maloney of New York</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>New York</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2308</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3212</office-zip-suffix>
+                <phone>(202) 225-7944</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="2" />
+                <committee comcode="EC00" rank="7" />
+                <committee comcode="GO00" rank="2" />
+                <subcommittee subcomcode="BA01" rank="2" />
+                <subcommittee subcomcode="BA15" rank="2" />
+                <subcommittee subcomcode="BA16" rank="1" />
+                <subcommittee subcomcode="GO24" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY13</statedistrict>
+            <member-info>
+                <namelist>Espaillat, Adriano</namelist>
+                <bioguideID>E000297</bioguideID>
+                <lastname>Espaillat</lastname>
+                <firstname>Adriano</firstname>
+                <middlename/>
+                <sort-name>ESPAILLAT,ADRIANO</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Adriano Espaillat</official-name>
+                <formal-name>Mr. Espaillat</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>New York</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1630</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3213</office-zip-suffix>
+                <phone>(202) 225-4365</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="17" />
+                <committee comcode="FA00" rank="20" />
+                <committee comcode="SM00" rank="8" />
+                <subcommittee subcomcode="ED02" rank="6" />
+                <subcommittee subcomcode="ED13" rank="10" />
+                <subcommittee subcomcode="FA07" rank="5" />
+                <subcommittee subcomcode="SM26" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY14</statedistrict>
+            <member-info>
+                <namelist>Crowley, Joseph</namelist>
+                <bioguideID>C001038</bioguideID>
+                <lastname>Crowley</lastname>
+                <firstname>Joseph</firstname>
+                <middlename/>
+                <sort-name>CROWLEY,JOSEPH</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Joseph Crowley</official-name>
+                <formal-name>Mr. Crowley</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Queens/Bronx</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1035</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3214</office-zip-suffix>
+                <phone>(202) 225-3965</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="10" />
+                <subcommittee subcomcode="WM01" rank="3" />
+                <subcommittee subcomcode="WM06" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY15</statedistrict>
+            <member-info>
+                <namelist>Serrano, José</namelist>
+                <bioguideID>S000248</bioguideID>
+                <lastname>Serrano</lastname>
+                <firstname>José</firstname>
+                <middlename>E.</middlename>
+                <sort-name>SERRANO,JOSE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>José E. Serrano</official-name>
+                <formal-name>Mr. Serrano</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>15th</district>
+                <townname>Bronx</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2354</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3215</office-zip-suffix>
+                <phone>(202) 225-4361</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="4" />
+                <subcommittee subcomcode="AP10" rank="5" />
+                <subcommittee subcomcode="AP19" rank="1" />
+                <subcommittee subcomcode="AP23" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY16</statedistrict>
+            <member-info>
+                <namelist>Engel, Eliot</namelist>
+                <bioguideID>E000179</bioguideID>
+                <lastname>Engel</lastname>
+                <firstname>Eliot</firstname>
+                <middlename>L.</middlename>
+                <sort-name>ENGEL,ELIOT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Eliot L. Engel</official-name>
+                <formal-name>Mr. Engel</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>16th</district>
+                <townname>Bronx</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2462</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3216</office-zip-suffix>
+                <phone>(202) 225-2464</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="1" />
+                <committee comcode="IF00" rank="4" />
+                <subcommittee subcomcode="IF14" rank="2" />
+                <subcommittee subcomcode="IF16" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY17</statedistrict>
+            <member-info>
+                <namelist>Lowey, Nita</namelist>
+                <bioguideID>L000480</bioguideID>
+                <lastname>Lowey</lastname>
+                <firstname>Nita</firstname>
+                <middlename>M.</middlename>
+                <sort-name>LOWEY,NITA</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Nita M. Lowey</official-name>
+                <formal-name>Mrs. Lowey</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>17th</district>
+                <townname>Harrison</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2365</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3217</office-zip-suffix>
+                <phone>(202) 225-6506</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="1" />
+                <subcommittee subcomcode="AP04" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY18</statedistrict>
+            <member-info>
+                <namelist>Maloney, Sean</namelist>
+                <bioguideID>M001185</bioguideID>
+                <lastname>Maloney</lastname>
+                <firstname>Sean</firstname>
+                <middlename>Patrick</middlename>
+                <sort-name>MALONEY,SEAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Sean Patrick Maloney</official-name>
+                <formal-name>Mr. Sean Patrick Maloney of New York</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>18th</district>
+                <townname>Cold Spring</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1027</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3218</office-zip-suffix>
+                <phone>(202) 225-5441</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="12" />
+                <committee comcode="PW00" rank="17" />
+                <subcommittee subcomcode="AG03" rank="9" />
+                <subcommittee subcomcode="AG16" rank="6" />
+                <subcommittee subcomcode="AG22" rank="2" />
+                <subcommittee subcomcode="PW02" rank="9" />
+                <subcommittee subcomcode="PW05" rank="8" />
+                <subcommittee subcomcode="PW12" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY19</statedistrict>
+            <member-info>
+                <namelist>Faso, John</namelist>
+                <bioguideID>F000464</bioguideID>
+                <lastname>Faso</lastname>
+                <firstname>John</firstname>
+                <middlename>J.</middlename>
+                <sort-name>FASO,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>John J. Faso</official-name>
+                <formal-name>Mr. Faso</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>19th</district>
+                <townname>Kinderhook</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1616</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3219</office-zip-suffix>
+                <phone>(202) 225-5614</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="24" />
+                <committee comcode="BU00" rank="18" />
+                <committee comcode="PW00" rank="31" />
+                <subcommittee subcomcode="AG03" rank="11" />
+                <subcommittee subcomcode="AG22" rank="8" />
+                <subcommittee subcomcode="PW12" rank="26" />
+                <subcommittee subcomcode="PW13" rank="6" />
+                <subcommittee subcomcode="PW14" rank="17" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY20</statedistrict>
+            <member-info>
+                <namelist>Tonko, Paul</namelist>
+                <bioguideID>T000469</bioguideID>
+                <lastname>Tonko</lastname>
+                <firstname>Paul</firstname>
+                <middlename/>
+                <sort-name>TONKO,PAUL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Paul Tonko</official-name>
+                <formal-name>Mr. Tonko</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>20th</district>
+                <townname>Amsterdam</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2463</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3220</office-zip-suffix>
+                <phone>(202) 225-5076</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="16" />
+                <committee comcode="SY00" rank="12" />
+                <subcommittee subcomcode="IF02" rank="4" />
+                <subcommittee subcomcode="IF03" rank="9" />
+                <subcommittee subcomcode="IF18" rank="1" />
+                <subcommittee subcomcode="SY20" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY21</statedistrict>
+            <member-info>
+                <namelist>Stefanik, Elise</namelist>
+                <bioguideID>S001196</bioguideID>
+                <lastname>Stefanik</lastname>
+                <firstname>Elise</firstname>
+                <middlename>M.</middlename>
+                <sort-name>STEFANIK,ELISE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Elise M. Stefanik</official-name>
+                <formal-name>Ms. Stefanik</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>21st</district>
+                <townname>Willsboro</townname>
+                <office-building>CHOB</office-building>
+                <office-room>318</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3221</office-zip-suffix>
+                <phone>(202) 225-4611</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="23" />
+                <committee comcode="ED00" rank="14" />
+                <committee comcode="IG00" rank="12" />
+                <subcommittee subcomcode="AS03" rank="7" />
+                <subcommittee subcomcode="AS26" rank="1" leadership="Chairwoman" />
+                <subcommittee subcomcode="ED10" rank="6" />
+                <subcommittee subcomcode="ED13" rank="7" />
+                <subcommittee subcomcode="IG02" rank="6" />
+                <subcommittee subcomcode="IG04" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY22</statedistrict>
+            <member-info>
+                <namelist>Tenney, Claudia</namelist>
+                <bioguideID>T000478</bioguideID>
+                <lastname>Tenney</lastname>
+                <firstname>Claudia</firstname>
+                <middlename/>
+                <sort-name>TENNEY,CLAUDIA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Claudia Tenney</official-name>
+                <formal-name>Ms. Tenney</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>22nd</district>
+                <townname>New Hartford</townname>
+                <office-building>CHOB</office-building>
+                <office-room>512</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3222</office-zip-suffix>
+                <phone>(202) 225-3665</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="33" />
+                <subcommittee subcomcode="BA09" rank="11" />
+                <subcommittee subcomcode="BA15" rank="15" />
+                <subcommittee subcomcode="BA20" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY23</statedistrict>
+            <member-info>
+                <namelist>Reed, Tom</namelist>
+                <bioguideID>R000585</bioguideID>
+                <lastname>Reed</lastname>
+                <firstname>Tom</firstname>
+                <middlename/>
+                <sort-name>REED,TOM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tom Reed</official-name>
+                <formal-name>Mr. Reed</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>23rd</district>
+                <townname>Corning</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2437</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3223</office-zip-suffix>
+                <phone>(202) 225-3161</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="13" />
+                <subcommittee subcomcode="WM02" rank="11" />
+                <subcommittee subcomcode="WM03" rank="7" />
+                <subcommittee subcomcode="WM04" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY24</statedistrict>
+            <member-info>
+                <namelist>Katko, John</namelist>
+                <bioguideID>K000386</bioguideID>
+                <lastname>Katko</lastname>
+                <firstname>John</firstname>
+                <middlename/>
+                <sort-name>KATKO,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John Katko</official-name>
+                <formal-name>Mr. Katko</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>24th</district>
+                <townname>Syracuse</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1620</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3224</office-zip-suffix>
+                <phone>(202) 225-3701</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="9" />
+                <committee comcode="PW00" rank="20" />
+                <subcommittee subcomcode="HM07" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="HM08" rank="2" />
+                <subcommittee subcomcode="PW02" rank="10" />
+                <subcommittee subcomcode="PW12" rank="16" />
+                <subcommittee subcomcode="PW14" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY25</statedistrict>
+            <member-info>
+                <namelist>Slaughter, Louise</namelist>
+                <bioguideID>S000480</bioguideID>
+                <lastname>Slaughter</lastname>
+                <firstname>Louise</firstname>
+                <middlename>McIntosh</middlename>
+                <sort-name>SLAUGHTER,LOUISE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Louise McIntosh Slaughter</official-name>
+                <formal-name>Ms. Slaughter</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>25th</district>
+                <townname>Fairport</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2469</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3225</office-zip-suffix>
+                <phone>(202) 225-3615</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="RU00" rank="1" />
+                <subcommittee subcomcode="RU04" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY26</statedistrict>
+            <member-info>
+                <namelist>Higgins, Brian</namelist>
+                <bioguideID>H001038</bioguideID>
+                <lastname>Higgins</lastname>
+                <firstname>Brian</firstname>
+                <middlename/>
+                <sort-name>HIGGINS,BRIAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Brian Higgins</official-name>
+                <formal-name>Mr. Higgins of New York</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>26th</district>
+                <townname>Buffalo</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2459</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3226</office-zip-suffix>
+                <phone>(202) 225-3306</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="6" />
+                <committee comcode="WM00" rank="13" />
+                <subcommittee subcomcode="WM02" rank="5" />
+                <subcommittee subcomcode="WM04" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>NY27</statedistrict>
+            <member-info>
+                <namelist>Collins, Chris</namelist>
+                <bioguideID>C001092</bioguideID>
+                <lastname>Collins</lastname>
+                <firstname>Chris</firstname>
+                <middlename/>
+                <sort-name>COLLINS,CHRIS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Chris Collins</official-name>
+                <formal-name>Mr. Collins of New York</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="NY">
+                    <state-fullname>New York</state-fullname>
+                </state>
+                <district>27th</district>
+                <townname>Clarence</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1117</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3227</office-zip-suffix>
+                <phone>(202) 225-5265</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="26" />
+                <subcommittee subcomcode="IF02" rank="6" />
+                <subcommittee subcomcode="IF14" rank="17" />
+                <subcommittee subcomcode="IF16" rank="14" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH01</statedistrict>
+            <member-info>
+                <namelist>Chabot, Steve</namelist>
+                <bioguideID>C000266</bioguideID>
+                <lastname>Chabot</lastname>
+                <firstname>Steve</firstname>
+                <middlename/>
+                <sort-name>CHABOT,STEVE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steve Chabot</official-name>
+                <formal-name>Mr. Chabot</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Cincinnati</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2371</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3501</office-zip-suffix>
+                <phone>(202) 225-2216</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="5" />
+                <committee comcode="JU00" rank="4" />
+                <committee comcode="SM00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="FA05" rank="3" />
+                <subcommittee subcomcode="FA13" rank="2" />
+                <subcommittee subcomcode="JU03" rank="4" />
+                <subcommittee subcomcode="JU08" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH02</statedistrict>
+            <member-info>
+                <namelist>Wenstrup, Brad</namelist>
+                <bioguideID>W000815</bioguideID>
+                <lastname>Wenstrup</lastname>
+                <firstname>Brad</firstname>
+                <middlename>R.</middlename>
+                <sort-name>WENSTRUP,BRAD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Brad R. Wenstrup</official-name>
+                <formal-name>Mr. Wenstrup</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Cincinnati</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2419</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3502</office-zip-suffix>
+                <phone>(202) 225-3164</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="20" />
+                <committee comcode="IG00" rank="8" />
+                <committee comcode="VR00" rank="4" />
+                <subcommittee subcomcode="AS02" rank="3" leadership="Vice Chair" />
+                <subcommittee subcomcode="AS26" rank="3" />
+                <subcommittee subcomcode="IG03" rank="3" />
+                <subcommittee subcomcode="IG04" rank="3" />
+                <subcommittee subcomcode="VR03" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="VR10" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH03</statedistrict>
+            <member-info>
+                <namelist>Beatty, Joyce</namelist>
+                <bioguideID>B001281</bioguideID>
+                <lastname>Beatty</lastname>
+                <firstname>Joyce</firstname>
+                <middlename/>
+                <sort-name>BEATTY,JOYCE</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Joyce Beatty</official-name>
+                <formal-name>Mrs. Beatty</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Columbus</townname>
+                <office-building>CHOB</office-building>
+                <office-room>133</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3503</office-zip-suffix>
+                <phone>(202) 225-4324</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="20" />
+                <subcommittee subcomcode="BA04" rank="6" />
+                <subcommittee subcomcode="BA09" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH04</statedistrict>
+            <member-info>
+                <namelist>Jordan, Jim</namelist>
+                <bioguideID>J000289</bioguideID>
+                <lastname>Jordan</lastname>
+                <firstname>Jim</firstname>
+                <middlename/>
+                <sort-name>JORDAN,JIM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jim Jordan</official-name>
+                <formal-name>Mr. Jordan</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Urbana</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2056</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3504</office-zip-suffix>
+                <phone>(202) 225-2676</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="4" />
+                <committee comcode="JU00" rank="9" />
+                <subcommittee subcomcode="GO24" rank="3" />
+                <subcommittee subcomcode="GO27" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="JU01" rank="5" />
+                <subcommittee subcomcode="JU03" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH05</statedistrict>
+            <member-info>
+                <namelist>Latta, Robert</namelist>
+                <bioguideID>L000566</bioguideID>
+                <lastname>Latta</lastname>
+                <firstname>Robert</firstname>
+                <middlename>E.</middlename>
+                <sort-name>LATTA,ROBERT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Robert E. Latta</official-name>
+                <formal-name>Mr. Latta</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Bowling Green</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2448</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3505</office-zip-suffix>
+                <phone>(202) 225-6405</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="9" />
+                <subcommittee subcomcode="IF03" rank="6" />
+                <subcommittee subcomcode="IF16" rank="5" />
+                <subcommittee subcomcode="IF17" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH06</statedistrict>
+            <member-info>
+                <namelist>Johnson, Bill</namelist>
+                <bioguideID>J000292</bioguideID>
+                <lastname>Johnson</lastname>
+                <firstname>Bill</firstname>
+                <middlename/>
+                <sort-name>JOHNSON,BILL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bill Johnson</official-name>
+                <formal-name>Mr. Johnson of Ohio</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Marietta</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1710</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3506</office-zip-suffix>
+                <phone>(202) 225-5705</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="14" />
+                <committee comcode="IF00" rank="19" />
+                <subcommittee subcomcode="IF03" rank="11" />
+                <subcommittee subcomcode="IF16" rank="10" />
+                <subcommittee subcomcode="IF18" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH07</statedistrict>
+            <member-info>
+                <namelist>Gibbs, Bob</namelist>
+                <bioguideID>G000563</bioguideID>
+                <lastname>Gibbs</lastname>
+                <firstname>Bob</firstname>
+                <middlename/>
+                <sort-name>GIBBS,BOB</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bob Gibbs</official-name>
+                <formal-name>Mr. Gibbs</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Lakeville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2446</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3507</office-zip-suffix>
+                <phone>(202) 225-6265</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="7" />
+                <committee comcode="PW00" rank="10" />
+                <subcommittee subcomcode="AG14" rank="2" />
+                <subcommittee subcomcode="AG16" rank="4" />
+                <subcommittee subcomcode="PW02" rank="3" />
+                <subcommittee subcomcode="PW05" rank="7" />
+                <subcommittee subcomcode="PW12" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH08</statedistrict>
+            <member-info>
+                <namelist>Davidson, Warren</namelist>
+                <bioguideID>D000626</bioguideID>
+                <lastname>Davidson</lastname>
+                <firstname>Warren</firstname>
+                <middlename/>
+                <sort-name>DAVIDSON,WARREN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Warren Davidson</official-name>
+                <formal-name>Mr. Davidson</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Troy</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1004</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3508</office-zip-suffix>
+                <phone>(202) 225-6205</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="30" />
+                <subcommittee subcomcode="BA01" rank="12" />
+                <subcommittee subcomcode="BA16" rank="14" />
+                <subcommittee subcomcode="BA20" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH09</statedistrict>
+            <member-info>
+                <namelist>Kaptur, Marcy</namelist>
+                <bioguideID>K000009</bioguideID>
+                <lastname>Kaptur</lastname>
+                <firstname>Marcy</firstname>
+                <middlename/>
+                <sort-name>KAPTUR,MARCY</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Marcy Kaptur</official-name>
+                <formal-name>Ms. Kaptur</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Toledo</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2186</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3509</office-zip-suffix>
+                <phone>(202) 225-4146</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="2" />
+                <subcommittee subcomcode="AP02" rank="5" />
+                <subcommittee subcomcode="AP06" rank="4" />
+                <subcommittee subcomcode="AP10" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH10</statedistrict>
+            <member-info>
+                <namelist>Turner, Michael</namelist>
+                <bioguideID>T000463</bioguideID>
+                <lastname>Turner</lastname>
+                <firstname>Michael</firstname>
+                <middlename>R.</middlename>
+                <sort-name>TURNER,MICHAEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Michael R. Turner</official-name>
+                <formal-name>Mr. Turner</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Dayton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2368</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3510</office-zip-suffix>
+                <phone>(202) 225-6465</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="6" />
+                <committee comcode="IG00" rank="7" />
+                <subcommittee subcomcode="AS25" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AS29" rank="7" />
+                <subcommittee subcomcode="IG02" rank="4" />
+                <subcommittee subcomcode="IG04" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH11</statedistrict>
+            <member-info>
+                <namelist>Fudge, Marcia</namelist>
+                <bioguideID>F000455</bioguideID>
+                <lastname>Fudge</lastname>
+                <firstname>Marcia</firstname>
+                <middlename>L.</middlename>
+                <sort-name>FUDGE,MARCIA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Marcia L. Fudge</official-name>
+                <formal-name>Ms. Fudge</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Warrensville Heights</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2344</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3511</office-zip-suffix>
+                <phone>(202) 225-7032</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="5" />
+                <committee comcode="ED00" rank="5" />
+                <subcommittee subcomcode="AG03" rank="4" />
+                <subcommittee subcomcode="AG15" rank="1" />
+                <subcommittee subcomcode="ED02" rank="8" />
+                <subcommittee subcomcode="ED14" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH12</statedistrict>
+            <member-info>
+                <namelist>Tiberi, Patrick</namelist>
+                <bioguideID>T000462</bioguideID>
+                <lastname>Tiberi</lastname>
+                <firstname>Patrick</firstname>
+                <middlename>J.</middlename>
+                <sort-name>TIBERI,PATRICK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Patrick J. Tiberi</official-name>
+                <formal-name>Mr. Tiberi</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Galena</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1203</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3512</office-zip-suffix>
+                <phone>(202) 225-5355</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="EC00" rank="1" leadership="Chairman" />
+                <committee comcode="WM00" rank="4" />
+                <subcommittee subcomcode="WM02" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="WM05" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH13</statedistrict>
+            <member-info>
+                <namelist>Ryan, Tim</namelist>
+                <bioguideID>R000577</bioguideID>
+                <lastname>Ryan</lastname>
+                <firstname>Tim</firstname>
+                <middlename/>
+                <sort-name>RYAN,TIM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tim Ryan</official-name>
+                <formal-name>Mr. Ryan of Ohio</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>Warren</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1126</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3513</office-zip-suffix>
+                <phone>(202) 225-5261</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="11" />
+                <subcommittee subcomcode="AP02" rank="3" />
+                <subcommittee subcomcode="AP18" rank="4" />
+                <subcommittee subcomcode="AP24" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH14</statedistrict>
+            <member-info>
+                <namelist>Joyce, David</namelist>
+                <bioguideID>J000295</bioguideID>
+                <lastname>Joyce</lastname>
+                <firstname>David</firstname>
+                <middlename>P.</middlename>
+                <sort-name>JOYCE,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David P. Joyce</official-name>
+                <formal-name>Mr. Joyce of Ohio</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Russell Township</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1124</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3514</office-zip-suffix>
+                <phone>(202) 225-5731</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="19" />
+                <subcommittee subcomcode="AP06" rank="4" />
+                <subcommittee subcomcode="AP10" rank="7" />
+                <subcommittee subcomcode="AP20" rank="3" leadership="Vice Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH15</statedistrict>
+            <member-info>
+                <namelist>Stivers, Steve</namelist>
+                <bioguideID>S001187</bioguideID>
+                <lastname>Stivers</lastname>
+                <firstname>Steve</firstname>
+                <middlename/>
+                <sort-name>STIVERS,STEVE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steve Stivers</official-name>
+                <formal-name>Mr. Stivers</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>15th</district>
+                <townname>Columbus</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1022</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3515</office-zip-suffix>
+                <phone>(202) 225-2015</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="11" />
+                <subcommittee subcomcode="BA04" rank="7" />
+                <subcommittee subcomcode="BA16" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OH16</statedistrict>
+            <member-info>
+                <namelist>Renacci, James</namelist>
+                <bioguideID>R000586</bioguideID>
+                <lastname>Renacci</lastname>
+                <firstname>James</firstname>
+                <middlename>B.</middlename>
+                <sort-name>RENACCI,JAMES</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>James B. Renacci</official-name>
+                <formal-name>Mr. Renacci</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OH">
+                    <state-fullname>Ohio</state-fullname>
+                </state>
+                <district>16th</district>
+                <townname>Wadsworth</townname>
+                <office-building>CHOB</office-building>
+                <office-room>328</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3516</office-zip-suffix>
+                <phone>(202) 225-3876</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="13" />
+                <committee comcode="WM00" rank="15" />
+                <subcommittee subcomcode="WM01" rank="6" />
+                <subcommittee subcomcode="WM05" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OK01</statedistrict>
+            <member-info>
+                <namelist>Bridenstine, Jim</namelist>
+                <bioguideID>B001283</bioguideID>
+                <lastname>Bridenstine</lastname>
+                <firstname>Jim</firstname>
+                <middlename/>
+                <sort-name>BRIDENSTINE,JIM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jim Bridenstine</official-name>
+                <formal-name>Mr. Bridenstine</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OK">
+                    <state-fullname>Oklahoma</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Tulsa</townname>
+                <office-building>CHOB</office-building>
+                <office-room>216</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3601</office-zip-suffix>
+                <phone>(202) 225-2211</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="19" />
+                <committee comcode="SY00" rank="8" />
+                <subcommittee subcomcode="AS28" rank="9" />
+                <subcommittee subcomcode="AS29" rank="6" />
+                <subcommittee subcomcode="SY16" rank="6" />
+                <subcommittee subcomcode="SY20" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OK02</statedistrict>
+            <member-info>
+                <namelist>Mullin, Markwayne</namelist>
+                <bioguideID>M001190</bioguideID>
+                <lastname>Mullin</lastname>
+                <firstname>Markwayne</firstname>
+                <middlename/>
+                <sort-name>MULLIN,MARKWAYNE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Markwayne Mullin</official-name>
+                <formal-name>Mr. Mullin</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OK">
+                    <state-fullname>Oklahoma</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Westville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1113</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3602</office-zip-suffix>
+                <phone>(202) 225-2701</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="24" />
+                <subcommittee subcomcode="IF03" rank="15" />
+                <subcommittee subcomcode="IF14" rank="15" />
+                <subcommittee subcomcode="IF17" rank="11" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OK03</statedistrict>
+            <member-info>
+                <namelist>Lucas, Frank</namelist>
+                <bioguideID>L000491</bioguideID>
+                <lastname>Lucas</lastname>
+                <firstname>Frank</firstname>
+                <middlename>D.</middlename>
+                <sort-name>LUCAS,FRANK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Frank D. Lucas</official-name>
+                <formal-name>Mr. Lucas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OK">
+                    <state-fullname>Oklahoma</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Cheyenne</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2405</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3603</office-zip-suffix>
+                <phone>(202) 225-5565</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="3" />
+                <committee comcode="BA00" rank="4" />
+                <committee comcode="SY00" rank="3" />
+                <subcommittee subcomcode="AG15" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AG16" rank="2" />
+                <subcommittee subcomcode="BA15" rank="4" />
+                <subcommittee subcomcode="BA20" rank="3" />
+                <subcommittee subcomcode="SY15" rank="2" />
+                <subcommittee subcomcode="SY16" rank="3" />
+                <subcommittee subcomcode="SY20" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OK04</statedistrict>
+            <member-info>
+                <namelist>Cole, Tom</namelist>
+                <bioguideID>C001053</bioguideID>
+                <lastname>Cole</lastname>
+                <firstname>Tom</firstname>
+                <middlename/>
+                <sort-name>COLE,TOM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tom Cole</official-name>
+                <formal-name>Mr. Cole</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OK">
+                    <state-fullname>Oklahoma</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Moore</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2467</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3604</office-zip-suffix>
+                <phone>(202) 225-6165</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="9" />
+                <committee comcode="BU00" rank="3" />
+                <committee comcode="RU00" rank="2" />
+                <subcommittee subcomcode="AP02" rank="4" />
+                <subcommittee subcomcode="AP06" rank="3" />
+                <subcommittee subcomcode="AP07" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OK05</statedistrict>
+            <member-info>
+                <namelist>Russell, Steve</namelist>
+                <bioguideID>R000604</bioguideID>
+                <lastname>Russell</lastname>
+                <firstname>Steve</firstname>
+                <middlename/>
+                <sort-name>RUSSELL,STEVE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steve Russell</official-name>
+                <formal-name>Mr. Russell</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OK">
+                    <state-fullname>Oklahoma</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Oklahoma City</townname>
+                <office-building>CHOB</office-building>
+                <office-room>128</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3605</office-zip-suffix>
+                <phone>(202) 225-2132</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="26" />
+                <committee comcode="GO00" rank="19" />
+                <subcommittee subcomcode="AS02" rank="4" />
+                <subcommittee subcomcode="AS03" rank="4" />
+                <subcommittee subcomcode="GO06" rank="2" leadership="Vice Chair" />
+                <subcommittee subcomcode="GO25" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OR01</statedistrict>
+            <member-info>
+                <namelist>Bonamici, Suzanne</namelist>
+                <bioguideID>B001278</bioguideID>
+                <lastname>Bonamici</lastname>
+                <firstname>Suzanne</firstname>
+                <middlename/>
+                <sort-name>BONAMICI,SUZANNE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Suzanne Bonamici</official-name>
+                <formal-name>Ms. Bonamici</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="OR">
+                    <state-fullname>Oregon</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Washington County</townname>
+                <office-building>CHOB</office-building>
+                <office-room>439</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3701</office-zip-suffix>
+                <phone>(202) 225-0855</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="9" />
+                <committee comcode="SY00" rank="4" />
+                <subcommittee subcomcode="ED02" rank="9" />
+                <subcommittee subcomcode="ED14" rank="4" />
+                <subcommittee subcomcode="SY15" rank="4" />
+                <subcommittee subcomcode="SY18" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OR02</statedistrict>
+            <member-info>
+                <namelist>Walden, Greg</namelist>
+                <bioguideID>W000791</bioguideID>
+                <lastname>Walden</lastname>
+                <firstname>Greg</firstname>
+                <middlename/>
+                <sort-name>WALDEN,GREG</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Greg Walden</official-name>
+                <formal-name>Mr. Walden</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="OR">
+                    <state-fullname>Oregon</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Hood River</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2185</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3702</office-zip-suffix>
+                <phone>(202) 225-6730</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="1" leadership="Chairman" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OR03</statedistrict>
+            <member-info>
+                <namelist>Blumenauer, Earl</namelist>
+                <bioguideID>B000574</bioguideID>
+                <lastname>Blumenauer</lastname>
+                <firstname>Earl</firstname>
+                <middlename/>
+                <sort-name>BLUMENAUER,EARL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Earl Blumenauer</official-name>
+                <formal-name>Mr. Blumenauer</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="OR">
+                    <state-fullname>Oregon</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Portland</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1111</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3703</office-zip-suffix>
+                <phone>(202) 225-4811</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="7" />
+                <subcommittee subcomcode="WM02" rank="4" />
+                <subcommittee subcomcode="WM05" rank="6" />
+                <subcommittee subcomcode="WM06" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OR04</statedistrict>
+            <member-info>
+                <namelist>DeFazio, Peter</namelist>
+                <bioguideID>D000191</bioguideID>
+                <lastname>DeFazio</lastname>
+                <firstname>Peter</firstname>
+                <middlename>A.</middlename>
+                <sort-name>DEFAZIO,PETER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Peter A. DeFazio</official-name>
+                <formal-name>Mr. DeFazio</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="OR">
+                    <state-fullname>Oregon</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Springfield</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2134</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3704</office-zip-suffix>
+                <phone>(202) 225-6416</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="PW00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>OR05</statedistrict>
+            <member-info>
+                <namelist>Schrader, Kurt</namelist>
+                <bioguideID>S001180</bioguideID>
+                <lastname>Schrader</lastname>
+                <firstname>Kurt</firstname>
+                <middlename/>
+                <sort-name>SCHRADER,KURT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kurt Schrader</official-name>
+                <formal-name>Mr. Schrader</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="OR">
+                    <state-fullname>Oregon</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Canby</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2431</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3705</office-zip-suffix>
+                <phone>(202) 225-5711</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170110">January 10, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="19" />
+                <subcommittee subcomcode="IF03" rank="11" />
+                <subcommittee subcomcode="IF14" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA01</statedistrict>
+            <member-info>
+                <namelist>Brady, Robert</namelist>
+                <bioguideID>B001227</bioguideID>
+                <lastname>Brady</lastname>
+                <firstname>Robert</firstname>
+                <middlename>A.</middlename>
+                <sort-name>BRADY,ROBERT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Robert A. Brady</official-name>
+                <formal-name>Mr. Brady of Pennsylvania</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Philadelphia</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2004</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3801</office-zip-suffix>
+                <phone>(202) 225-4731</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="2" />
+                <committee comcode="HA00" rank="1" />
+                <committee comcode="JL00" rank="4" />
+                <committee comcode="JP00" rank="4" />
+                <subcommittee subcomcode="AS02" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA02</statedistrict>
+            <member-info>
+                <namelist>Evans, Dwight</namelist>
+                <bioguideID>E000296</bioguideID>
+                <lastname>Evans</lastname>
+                <firstname>Dwight</firstname>
+                <middlename/>
+                <sort-name>EVANS,DWIGHT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Dwight Evans</official-name>
+                <formal-name>Mr. Evans</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Philadelphia</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1105</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3802</office-zip-suffix>
+                <phone>(202) 225-4001</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="15" />
+                <committee comcode="SM00" rank="2" />
+                <subcommittee subcomcode="AG03" rank="3" />
+                <subcommittee subcomcode="AG29" rank="5" />
+                <subcommittee subcomcode="SM23" rank="3" />
+                <subcommittee subcomcode="SM27" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA03</statedistrict>
+            <member-info>
+                <namelist>Kelly, Mike</namelist>
+                <bioguideID>K000376</bioguideID>
+                <lastname>Kelly</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>KELLY,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mike Kelly</official-name>
+                <formal-name>Mr. Kelly of Pennsylvania</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Butler</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1707</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3803</office-zip-suffix>
+                <phone>(202) 225-5406</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="14" />
+                <subcommittee subcomcode="WM01" rank="5" />
+                <subcommittee subcomcode="WM04" rank="5" />
+                <subcommittee subcomcode="WM05" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA04</statedistrict>
+            <member-info>
+                <namelist>Perry, Scott</namelist>
+                <bioguideID>P000605</bioguideID>
+                <lastname>Perry</lastname>
+                <firstname>Scott</firstname>
+                <middlename/>
+                <sort-name>PERRY,SCOTT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Scott Perry</official-name>
+                <formal-name>Mr. Perry</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Dillsburg</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1207</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3804</office-zip-suffix>
+                <phone>(202) 225-5836</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="14" />
+                <committee comcode="HM00" rank="8" />
+                <committee comcode="PW00" rank="15" />
+                <subcommittee subcomcode="FA05" rank="6" />
+                <subcommittee subcomcode="FA18" rank="5" />
+                <subcommittee subcomcode="HM05" rank="3" />
+                <subcommittee subcomcode="HM09" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="PW05" rank="12" />
+                <subcommittee subcomcode="PW12" rank="13" />
+                <subcommittee subcomcode="PW14" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA05</statedistrict>
+            <member-info>
+                <namelist>Thompson, Glenn</namelist>
+                <bioguideID>T000467</bioguideID>
+                <lastname>Thompson</lastname>
+                <firstname>Glenn</firstname>
+                <middlename/>
+                <sort-name>THOMPSON,GLENN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Glenn Thompson</official-name>
+                <formal-name>Mr. Thompson of Pennsylvania</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Howard</townname>
+                <office-building>CHOB</office-building>
+                <office-room>124</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3805</office-zip-suffix>
+                <phone>(202) 225-5121</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="6" />
+                <committee comcode="ED00" rank="5" />
+                <committee comcode="II00" rank="8" />
+                <subcommittee subcomcode="AG03" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AG15" rank="2" />
+                <subcommittee subcomcode="ED13" rank="2" />
+                <subcommittee subcomcode="ED14" rank="4" />
+                <subcommittee subcomcode="II06" rank="6" />
+                <subcommittee subcomcode="II10" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA06</statedistrict>
+            <member-info>
+                <namelist>Costello, Ryan</namelist>
+                <bioguideID>C001106</bioguideID>
+                <lastname>Costello</lastname>
+                <firstname>Ryan</firstname>
+                <middlename>A.</middlename>
+                <sort-name>COSTELLO,RYAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ryan A. Costello</official-name>
+                <formal-name>Mr. Costello of Pennsylvania</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>West Chester</townname>
+                <office-building>CHOB</office-building>
+                <office-room>326</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3806</office-zip-suffix>
+                <phone>(202) 225-4315</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="30" />
+                <subcommittee subcomcode="IF02" rank="9" />
+                <subcommittee subcomcode="IF16" rank="17" />
+                <subcommittee subcomcode="IF17" rank="13" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA07</statedistrict>
+            <member-info>
+                <namelist>Meehan, Patrick</namelist>
+                <bioguideID>M001181</bioguideID>
+                <lastname>Meehan</lastname>
+                <firstname>Patrick</firstname>
+                <middlename/>
+                <sort-name>MEEHAN,PATRICK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Patrick Meehan</official-name>
+                <formal-name>Mr. Meehan</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Chadds Ford</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2305</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3807</office-zip-suffix>
+                <phone>(202) 225-2011</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="SO00" rank="2" />
+                <committee comcode="WM00" rank="16" />
+                <subcommittee subcomcode="WM04" rank="6" />
+                <subcommittee subcomcode="WM05" rank="9" />
+                <subcommittee subcomcode="WM06" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA08</statedistrict>
+            <member-info>
+                <namelist>Fitzpatrick, Brian</namelist>
+                <bioguideID>F000466</bioguideID>
+                <lastname>Fitzpatrick</lastname>
+                <firstname>Brian</firstname>
+                <middlename>K.</middlename>
+                <sort-name>FITZPATRICK,BRIAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Brian K. Fitzpatrick</official-name>
+                <formal-name>Mr. Fitzpatrick</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Levittown</townname>
+                <office-building>CHOB</office-building>
+                <office-room>514</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3808</office-zip-suffix>
+                <phone>(202) 225-4276</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="25" />
+                <committee comcode="HM00" rank="18" />
+                <committee comcode="SM00" rank="12" />
+                <subcommittee subcomcode="FA13" rank="12" />
+                <subcommittee subcomcode="FA14" rank="8" />
+                <subcommittee subcomcode="HM07" rank="5" />
+                <subcommittee subcomcode="HM08" rank="7" />
+                <subcommittee subcomcode="SM26" rank="5" />
+                <subcommittee subcomcode="SM27" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA09</statedistrict>
+            <member-info>
+                <namelist>Shuster, Bill</namelist>
+                <bioguideID>S001154</bioguideID>
+                <lastname>Shuster</lastname>
+                <firstname>Bill</firstname>
+                <middlename/>
+                <sort-name>SHUSTER,BILL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bill Shuster</official-name>
+                <formal-name>Mr. Shuster</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Hollidaysburg</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2079</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3809</office-zip-suffix>
+                <phone>(202) 225-2431</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="9" />
+                <committee comcode="PW00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AS26" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA10</statedistrict>
+            <member-info>
+                <namelist>Marino, Tom</namelist>
+                <bioguideID>M001179</bioguideID>
+                <lastname>Marino</lastname>
+                <firstname>Tom</firstname>
+                <middlename/>
+                <sort-name>MARINO,TOM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tom Marino</official-name>
+                <formal-name>Mr. Marino</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Williamsport</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2242</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3810</office-zip-suffix>
+                <phone>(202) 225-3731</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="10" />
+                <committee comcode="HM00" rank="6" />
+                <committee comcode="JU00" rank="12" />
+                <subcommittee subcomcode="FA05" rank="4" />
+                <subcommittee subcomcode="FA14" rank="4" />
+                <subcommittee subcomcode="HM09" rank="3" />
+                <subcommittee subcomcode="HM12" rank="2" />
+                <subcommittee subcomcode="JU03" rank="9" />
+                <subcommittee subcomcode="JU05" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA11</statedistrict>
+            <member-info>
+                <namelist>Barletta, Lou</namelist>
+                <bioguideID>B001269</bioguideID>
+                <lastname>Barletta</lastname>
+                <firstname>Lou</firstname>
+                <middlename/>
+                <sort-name>BARLETTA,LOU</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Lou Barletta</official-name>
+                <formal-name>Mr. Barletta</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Hazleton</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2049</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3811</office-zip-suffix>
+                <phone>(202) 225-6511</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="9" />
+                <committee comcode="HM00" rank="7" />
+                <committee comcode="PW00" rank="8" />
+                <subcommittee subcomcode="ED02" rank="5" />
+                <subcommittee subcomcode="ED13" rank="3" />
+                <subcommittee subcomcode="HM05" rank="2" />
+                <subcommittee subcomcode="HM11" rank="5" />
+                <subcommittee subcomcode="PW12" rank="7" />
+                <subcommittee subcomcode="PW13" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="PW14" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA12</statedistrict>
+            <member-info>
+                <namelist>Rothfus, Keith</namelist>
+                <bioguideID>R000598</bioguideID>
+                <lastname>Rothfus</lastname>
+                <firstname>Keith</firstname>
+                <middlename>J.</middlename>
+                <sort-name>ROTHFUS,KEITH</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Keith J. Rothfus</official-name>
+                <formal-name>Mr. Rothfus</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Sewickley</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1205</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3812</office-zip-suffix>
+                <phone>(202) 225-2065</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="17" />
+                <subcommittee subcomcode="BA01" rank="3" />
+                <subcommittee subcomcode="BA04" rank="9" />
+                <subcommittee subcomcode="BA15" rank="2" leadership="Vice Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA13</statedistrict>
+            <member-info>
+                <namelist>Boyle, Brendan</namelist>
+                <bioguideID>B001296</bioguideID>
+                <lastname>Boyle</lastname>
+                <firstname>Brendan</firstname>
+                <middlename>F.</middlename>
+                <sort-name>BOYLE,BRENDAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Brendan F. Boyle</official-name>
+                <formal-name>Mr. Brendan F. Boyle of Pennsylvania</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>Philadelphia</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1133</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3813</office-zip-suffix>
+                <phone>(202) 225-6111</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="9" />
+                <committee comcode="FA00" rank="15" />
+                <subcommittee subcomcode="FA13" rank="5" />
+                <subcommittee subcomcode="FA18" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA14</statedistrict>
+            <member-info>
+                <namelist>Doyle, Michael</namelist>
+                <bioguideID>D000482</bioguideID>
+                <lastname>Doyle</lastname>
+                <firstname>Michael</firstname>
+                <middlename>F.</middlename>
+                <sort-name>DOYLE,MICHAEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Michael F. Doyle</official-name>
+                <formal-name>Mr. Michael F. Doyle of Pennsylvania</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Pittsburgh</townname>
+                <office-building>CHOB</office-building>
+                <office-room>239</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3814</office-zip-suffix>
+                <phone>(202) 225-2135</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="7" />
+                <subcommittee subcomcode="IF03" rank="5" />
+                <subcommittee subcomcode="IF16" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA15</statedistrict>
+            <member-info>
+                <namelist>Dent, Charles</namelist>
+                <bioguideID>D000604</bioguideID>
+                <lastname>Dent</lastname>
+                <firstname>Charles</firstname>
+                <middlename>W.</middlename>
+                <sort-name>DENT,CHARLES</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Charles W. Dent</official-name>
+                <formal-name>Mr. Dent</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>15th</district>
+                <townname>Allentown</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2082</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3815</office-zip-suffix>
+                <phone>(202) 225-6411</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="11" />
+                <subcommittee subcomcode="AP04" rank="4" />
+                <subcommittee subcomcode="AP18" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AP20" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA16</statedistrict>
+            <member-info>
+                <namelist>Smucker, Lloyd</namelist>
+                <bioguideID>S001199</bioguideID>
+                <lastname>Smucker</lastname>
+                <firstname>Lloyd</firstname>
+                <middlename/>
+                <sort-name>SMUCKER,LLOYD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Lloyd Smucker</official-name>
+                <formal-name>Mr. Smucker</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>16th</district>
+                <townname>Lancaster</townname>
+                <office-building>CHOB</office-building>
+                <office-room>516</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3816</office-zip-suffix>
+                <phone>(202) 225-2411</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="19" />
+                <committee comcode="ED00" rank="20" />
+                <committee comcode="PW00" rank="29" />
+                <subcommittee subcomcode="ED02" rank="10" />
+                <subcommittee subcomcode="ED13" rank="12" />
+                <subcommittee subcomcode="PW12" rank="24" />
+                <subcommittee subcomcode="PW13" rank="5" />
+                <subcommittee subcomcode="PW14" rank="15" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA17</statedistrict>
+            <member-info>
+                <namelist>Cartwright, Matt</namelist>
+                <bioguideID>C001090</bioguideID>
+                <lastname>Cartwright</lastname>
+                <firstname>Matt</firstname>
+                <middlename/>
+                <sort-name>CARTWRIGHT,MATT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Matt Cartwright</official-name>
+                <formal-name>Mr. Cartwright</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>17th</district>
+                <townname>Moosic</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1034</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3817</office-zip-suffix>
+                <phone>(202) 225-5546</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="18" />
+                <committee comcode="GO00" rank="16" />
+                <subcommittee subcomcode="AP19" rank="3" />
+                <subcommittee subcomcode="AP23" rank="3" />
+                <subcommittee subcomcode="GO29" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PA18</statedistrict>
+            <member-info>
+                <namelist>Murphy, Tim</namelist>
+                <bioguideID>M001151</bioguideID>
+                <lastname>Murphy</lastname>
+                <firstname>Tim</firstname>
+                <middlename/>
+                <sort-name>MURPHY,TIM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tim Murphy</official-name>
+                <formal-name>Mr. Murphy of Pennsylvania</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PA">
+                    <state-fullname>Pennsylvania</state-fullname>
+                </state>
+                <district>18th</district>
+                <townname>Pittsburgh</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2332</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3818</office-zip-suffix>
+                <phone>(202) 225-2301</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="5" />
+                <subcommittee subcomcode="IF02" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="IF03" rank="5" />
+                <subcommittee subcomcode="IF14" rank="6" />
+                <subcommittee subcomcode="IF18" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>PR00</statedistrict>
+            <member-info>
+                <namelist>González-Colón, Jenniffer</namelist>
+                <bioguideID>G000582</bioguideID>
+                <lastname>González-Colón</lastname>
+                <firstname>Jenniffer</firstname>
+                <middlename/>
+                <sort-name>GONZALEZCOLON,JENNIFFER</sort-name>
+                <suffix/>
+                <courtesy>Miss</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Jenniffer González-Colón</official-name>
+                <formal-name>Miss González-Colón of Puerto Rico</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="PR">
+                    <state-fullname>Puerto Rico</state-fullname>
+                </state>
+                <district>Resident Commissioner</district>
+                <townname>San Juan</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1529</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>5401</office-zip-suffix>
+                <phone>(202) 225-2615</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="25" />
+                <committee comcode="SM00" rank="10" />
+                <committee comcode="VR00" rank="14" />
+                <subcommittee subcomcode="II15" rank="6" />
+                <subcommittee subcomcode="II24" rank="8" />
+                <subcommittee subcomcode="SM26" rank="4" />
+                <subcommittee subcomcode="SM27" rank="4" />
+                <subcommittee subcomcode="VR03" rank="7" />
+                <subcommittee subcomcode="VR08" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>RI01</statedistrict>
+            <member-info>
+                <namelist>Cicilline, David</namelist>
+                <bioguideID>C001084</bioguideID>
+                <lastname>Cicilline</lastname>
+                <firstname>David</firstname>
+                <middlename>N.</middlename>
+                <sort-name>CICILLINE,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David N. Cicilline</official-name>
+                <formal-name>Mr. Cicilline</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="RI">
+                    <state-fullname>Rhode Island</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Providence</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2244</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3901</office-zip-suffix>
+                <phone>(202) 225-4911</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="9" />
+                <committee comcode="JU00" rank="12" />
+                <subcommittee subcomcode="FA13" rank="3" />
+                <subcommittee subcomcode="FA14" rank="5" />
+                <subcommittee subcomcode="JU05" rank="1" />
+                <subcommittee subcomcode="JU08" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>RI02</statedistrict>
+            <member-info>
+                <namelist>Langevin, James</namelist>
+                <bioguideID>L000559</bioguideID>
+                <lastname>Langevin</lastname>
+                <firstname>James</firstname>
+                <middlename>R.</middlename>
+                <sort-name>LANGEVIN,JAMES</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>James R. Langevin</official-name>
+                <formal-name>Mr. Langevin</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="RI">
+                    <state-fullname>Rhode Island</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Warwick</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2077</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>3902</office-zip-suffix>
+                <phone>(202) 225-2735</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="4" />
+                <committee comcode="HM00" rank="3" />
+                <subcommittee subcomcode="AS25" rank="2" />
+                <subcommittee subcomcode="AS26" rank="1" />
+                <subcommittee subcomcode="AS28" rank="3" />
+                <subcommittee subcomcode="HM08" rank="3" />
+                <subcommittee subcomcode="HM12" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>SC01</statedistrict>
+            <member-info>
+                <namelist>Sanford, Mark</namelist>
+                <bioguideID>S000051</bioguideID>
+                <lastname>Sanford</lastname>
+                <firstname>Mark</firstname>
+                <middlename/>
+                <sort-name>SANFORD,MARK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mark Sanford</official-name>
+                <formal-name>Mr. Sanford</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="SC">
+                    <state-fullname>South Carolina</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Charleston</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2211</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4001</office-zip-suffix>
+                <phone>(202) 225-3176</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="7" />
+                <committee comcode="GO00" rank="5" />
+                <committee comcode="PW00" rank="17" />
+                <subcommittee subcomcode="GO24" rank="4" />
+                <subcommittee subcomcode="GO27" rank="4" />
+                <subcommittee subcomcode="PW02" rank="7" />
+                <subcommittee subcomcode="PW05" rank="14" />
+                <subcommittee subcomcode="PW14" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>SC02</statedistrict>
+            <member-info>
+                <namelist>Wilson, Joe</namelist>
+                <bioguideID>W000795</bioguideID>
+                <lastname>Wilson</lastname>
+                <firstname>Joe</firstname>
+                <middlename/>
+                <sort-name>WILSON,JOE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Joe Wilson</official-name>
+                <formal-name>Mr. Wilson of South Carolina</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="SC">
+                    <state-fullname>South Carolina</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Springdale</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1436</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4002</office-zip-suffix>
+                <phone>(202) 225-2452</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="3" />
+                <committee comcode="ED00" rank="2" leadership="Vice Chair" />
+                <committee comcode="FA00" rank="6" />
+                <subcommittee subcomcode="AS03" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AS26" rank="6" />
+                <subcommittee subcomcode="ED02" rank="2" />
+                <subcommittee subcomcode="ED10" rank="2" />
+                <subcommittee subcomcode="FA14" rank="2" />
+                <subcommittee subcomcode="FA18" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>SC03</statedistrict>
+            <member-info>
+                <namelist>Duncan, Jeff</namelist>
+                <bioguideID>D000615</bioguideID>
+                <lastname>Duncan</lastname>
+                <firstname>Jeff</firstname>
+                <middlename/>
+                <sort-name>DUNCAN,JEFF</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jeff Duncan</official-name>
+                <formal-name>Mr. Duncan of South Carolina</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="SC">
+                    <state-fullname>South Carolina</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Laurens</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2229</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4003</office-zip-suffix>
+                <phone>(202) 225-5301</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="11" />
+                <committee comcode="HM00" rank="5" />
+                <subcommittee subcomcode="FA07" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="FA14" rank="5" />
+                <subcommittee subcomcode="HM09" rank="2" />
+                <subcommittee subcomcode="HM11" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>SC04</statedistrict>
+            <member-info>
+                <namelist>Gowdy, Trey</namelist>
+                <bioguideID>G000566</bioguideID>
+                <lastname>Gowdy</lastname>
+                <firstname>Trey</firstname>
+                <middlename/>
+                <sort-name>GOWDY,TREY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Trey Gowdy</official-name>
+                <formal-name>Mr. Gowdy</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="SC">
+                    <state-fullname>South Carolina</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Spartanburg</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2418</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4004</office-zip-suffix>
+                <phone>(202) 225-6030</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="9" />
+                <committee comcode="IG00" rank="11" />
+                <committee comcode="JU00" rank="13" />
+                <committee comcode="SO00" rank="3" />
+                <subcommittee subcomcode="GO29" rank="4" />
+                <subcommittee subcomcode="IG02" rank="5" />
+                <subcommittee subcomcode="IG03" rank="5" />
+                <subcommittee subcomcode="JU08" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="JU10" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>SC05</statedistrict>
+            <member-info>
+                <namelist/>
+                <bioguideID/>
+                <lastname/>
+                <firstname/>
+                <middlename/>
+                <sort-name/>
+                <suffix/>
+                <courtesy/>
+                <prior-congress>0</prior-congress>
+                <official-name/>
+                <formal-name/>
+                <party/>
+                <caucus/>
+                <state postal-code="SC">
+                    <state-fullname>South Carolina</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname/>
+                <office-building>RHOB</office-building>
+                <office-room>2350</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4005</office-zip-suffix>
+                <phone>(202) 225-5501</phone>
+                <elected-date date="" />
+                <sworn-date date="" />
+                <footnote-ref>0</footnote-ref>
+                <footnote>Vacancy due to the resignation of Mick Mulvaney, February 16, 2017.</footnote>
+            </member-info>
+            <predecessor-info cause="R">
+                <pred-lastname>Mulvaney</pred-lastname>
+                <pred-firstname>Mick</pred-firstname>
+                <pred-middlename/>
+                <pred-official-name>Mick Mulvaney</pred-official-name>
+                <pred-formal-name>Mr. Mulvaney</pred-formal-name>
+                <pred-memindex>M001182</pred-memindex>
+                <pred-sort-name>MULVANEY,MICK</pred-sort-name>
+                <pred-party>R</pred-party>
+                <pred-vacate-date date="20170216">February 16, 2017</pred-vacate-date>
+                <pred-footnote-ref>0</pred-footnote-ref>
+                <pred-footnote>Vacancy due to the resignation of Mick Mulvaney, February 16, 2017.</pred-footnote>
+            </predecessor-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>SC06</statedistrict>
+            <member-info>
+                <namelist>Clyburn, James</namelist>
+                <bioguideID>C000537</bioguideID>
+                <lastname>Clyburn</lastname>
+                <firstname>James</firstname>
+                <middlename>E.</middlename>
+                <sort-name>CLYBURN,JAMES</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>James E. Clyburn</official-name>
+                <formal-name>Mr. Clyburn</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="SC">
+                    <state-fullname>South Carolina</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Columbia</townname>
+                <office-building>CHOB</office-building>
+                <office-room>242</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4006</office-zip-suffix>
+                <phone>(202) 225-3315</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>SC07</statedistrict>
+            <member-info>
+                <namelist>Rice, Tom</namelist>
+                <bioguideID>R000597</bioguideID>
+                <lastname>Rice</lastname>
+                <firstname>Tom</firstname>
+                <middlename/>
+                <sort-name>RICE,TOM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Tom Rice</official-name>
+                <formal-name>Mr. Rice of South Carolina</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="SC">
+                    <state-fullname>South Carolina</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Myrtle Beach</townname>
+                <office-building>CHOB</office-building>
+                <office-room>223</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4007</office-zip-suffix>
+                <phone>(202) 225-9895</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="20" />
+                <subcommittee subcomcode="WM01" rank="2" />
+                <subcommittee subcomcode="WM04" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>SD00</statedistrict>
+            <member-info>
+                <namelist>Noem, Kristi</namelist>
+                <bioguideID>N000184</bioguideID>
+                <lastname>Noem</lastname>
+                <firstname>Kristi</firstname>
+                <middlename>L.</middlename>
+                <sort-name>NOEM,KRISTI</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kristi L. Noem</official-name>
+                <formal-name>Mrs. Noem</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="SD">
+                    <state-fullname>South Dakota</state-fullname>
+                </state>
+                <district>At Large</district>
+                <townname>Castlewood</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2457</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4100</office-zip-suffix>
+                <phone>(202) 225-2801</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="17" />
+                <subcommittee subcomcode="WM04" rank="8" />
+                <subcommittee subcomcode="WM05" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN01</statedistrict>
+            <member-info>
+                <namelist>Roe, David</namelist>
+                <bioguideID>R000582</bioguideID>
+                <lastname>Roe</lastname>
+                <firstname>David</firstname>
+                <middlename>P.</middlename>
+                <sort-name>ROE,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David P. Roe</official-name>
+                <formal-name>Mr. Roe of Tennessee</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Johnson City</townname>
+                <office-building>CHOB</office-building>
+                <office-room>336</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4201</office-zip-suffix>
+                <phone>(202) 225-6356</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="4" />
+                <committee comcode="VR00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="ED02" rank="3" />
+                <subcommittee subcomcode="ED14" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN02</statedistrict>
+            <member-info>
+                <namelist>Duncan, John</namelist>
+                <bioguideID>D000533</bioguideID>
+                <lastname>Duncan</lastname>
+                <firstname>John</firstname>
+                <middlename>J.</middlename>
+                <sort-name>DUNCAN,JOHN</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John J. Duncan, Jr.</official-name>
+                <formal-name>Mr. Duncan of Tennessee</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Knoxville</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2207</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4202</office-zip-suffix>
+                <phone>(202) 225-5435</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="2" />
+                <committee comcode="PW00" rank="3" leadership="Vice Chair" />
+                <subcommittee subcomcode="GO06" rank="3" />
+                <subcommittee subcomcode="GO29" rank="3" />
+                <subcommittee subcomcode="PW05" rank="3" />
+                <subcommittee subcomcode="PW12" rank="3" />
+                <subcommittee subcomcode="PW14" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN03</statedistrict>
+            <member-info>
+                <namelist>Fleischmann, Charles</namelist>
+                <bioguideID>F000459</bioguideID>
+                <lastname>Fleischmann</lastname>
+                <firstname>Charles</firstname>
+                <middlename>J. "Chuck"</middlename>
+                <sort-name>FLEISCHMANN,CHARLES</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Charles J. "Chuck" Fleischmann</official-name>
+                <formal-name>Mr. Fleischmann</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Chattanooga</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2410</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4203</office-zip-suffix>
+                <phone>(202) 225-3271</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="17" />
+                <subcommittee subcomcode="AP07" rank="4" />
+                <subcommittee subcomcode="AP10" rank="3" leadership="Vice Chair" />
+                <subcommittee subcomcode="AP15" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN04</statedistrict>
+            <member-info>
+                <namelist>DesJarlais, Scott</namelist>
+                <bioguideID>D000616</bioguideID>
+                <lastname>DesJarlais</lastname>
+                <firstname>Scott</firstname>
+                <middlename/>
+                <sort-name>DESJARLAIS,SCOTT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Scott DesJarlais</official-name>
+                <formal-name>Mr. DesJarlais</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>South Pittsburg</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2301</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4204</office-zip-suffix>
+                <phone>(202) 225-6831</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="10" />
+                <committee comcode="AS00" rank="27" />
+                <committee comcode="GO00" rank="8" />
+                <subcommittee subcomcode="AG03" rank="4" />
+                <subcommittee subcomcode="AG16" rank="6" />
+                <subcommittee subcomcode="AG29" rank="4" />
+                <subcommittee subcomcode="AS03" rank="9" />
+                <subcommittee subcomcode="AS28" rank="5" />
+                <subcommittee subcomcode="GO27" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN05</statedistrict>
+            <member-info>
+                <namelist>Cooper, Jim</namelist>
+                <bioguideID>C000754</bioguideID>
+                <lastname>Cooper</lastname>
+                <firstname>Jim</firstname>
+                <middlename/>
+                <sort-name>COOPER,JIM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jim Cooper</official-name>
+                <formal-name>Mr. Cooper</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Nashville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1536</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4205</office-zip-suffix>
+                <phone>(202) 225-4311</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="6" />
+                <committee comcode="GO00" rank="6" />
+                <subcommittee subcomcode="AS25" rank="3" />
+                <subcommittee subcomcode="AS26" rank="3" />
+                <subcommittee subcomcode="AS29" rank="1" />
+                <subcommittee subcomcode="GO27" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN06</statedistrict>
+            <member-info>
+                <namelist>Black, Diane</namelist>
+                <bioguideID>B001273</bioguideID>
+                <lastname>Black</lastname>
+                <firstname>Diane</firstname>
+                <middlename/>
+                <sort-name>BLACK,DIANE</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Diane Black</official-name>
+                <formal-name>Mrs. Black</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Gallatin</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1131</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4206</office-zip-suffix>
+                <phone>(202) 225-4231</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="1" leadership="Chairman" />
+                <committee comcode="WM00" rank="12" />
+                <subcommittee subcomcode="WM02" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN07</statedistrict>
+            <member-info>
+                <namelist>Blackburn, Marsha</namelist>
+                <bioguideID>B001243</bioguideID>
+                <lastname>Blackburn</lastname>
+                <firstname>Marsha</firstname>
+                <middlename/>
+                <sort-name>BLACKBURN,MARSHA</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Marsha Blackburn</official-name>
+                <formal-name>Mrs. Blackburn</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Brentwood</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2266</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4207</office-zip-suffix>
+                <phone>(202) 225-2811</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="7" />
+                <subcommittee subcomcode="IF14" rank="7" />
+                <subcommittee subcomcode="IF16" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="IF18" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN08</statedistrict>
+            <member-info>
+                <namelist>Kustoff, David</namelist>
+                <bioguideID>K000392</bioguideID>
+                <lastname>Kustoff</lastname>
+                <firstname>David</firstname>
+                <middlename/>
+                <sort-name>KUSTOFF,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>David Kustoff</official-name>
+                <formal-name>Mr. Kustoff of Tennessee</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Germantown</townname>
+                <office-building>CHOB</office-building>
+                <office-room>508</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4208</office-zip-suffix>
+                <phone>(202) 225-4714</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="32" />
+                <subcommittee subcomcode="BA01" rank="14" />
+                <subcommittee subcomcode="BA09" rank="10" />
+                <subcommittee subcomcode="BA15" rank="14" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TN09</statedistrict>
+            <member-info>
+                <namelist>Cohen, Steve</namelist>
+                <bioguideID>C001068</bioguideID>
+                <lastname>Cohen</lastname>
+                <firstname>Steve</firstname>
+                <middlename/>
+                <sort-name>COHEN,STEVE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Steve Cohen</official-name>
+                <formal-name>Mr. Cohen</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TN">
+                    <state-fullname>Tennessee</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Memphis</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2404</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4209</office-zip-suffix>
+                <phone>(202) 225-3265</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="JU00" rank="5" />
+                <committee comcode="PW00" rank="10" />
+                <committee comcode="SO00" rank="5" />
+                <subcommittee subcomcode="JU03" rank="11" />
+                <subcommittee subcomcode="JU10" rank="1" />
+                <subcommittee subcomcode="PW05" rank="14" />
+                <subcommittee subcomcode="PW12" rank="3" />
+                <subcommittee subcomcode="PW14" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX01</statedistrict>
+            <member-info>
+                <namelist>Gohmert, Louie</namelist>
+                <bioguideID>G000552</bioguideID>
+                <lastname>Gohmert</lastname>
+                <firstname>Louie</firstname>
+                <middlename/>
+                <sort-name>GOHMERT,LOUIE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Louie Gohmert</official-name>
+                <formal-name>Mr. Gohmert</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Tyler</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2243</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4301</office-zip-suffix>
+                <phone>(202) 225-3035</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="II00" rank="3" />
+                <committee comcode="JU00" rank="8" />
+                <subcommittee subcomcode="II06" rank="2" />
+                <subcommittee subcomcode="II15" rank="2" />
+                <subcommittee subcomcode="JU08" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="JU10" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX02</statedistrict>
+            <member-info>
+                <namelist>Poe, Ted</namelist>
+                <bioguideID>P000592</bioguideID>
+                <lastname>Poe</lastname>
+                <firstname>Ted</firstname>
+                <middlename/>
+                <sort-name>POE,TED</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ted Poe</official-name>
+                <formal-name>Mr. Poe of Texas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Atascocita</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2132</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4302</office-zip-suffix>
+                <phone>(202) 225-6565</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="8" />
+                <committee comcode="JU00" rank="10" />
+                <subcommittee subcomcode="FA14" rank="3" />
+                <subcommittee subcomcode="FA18" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="JU03" rank="7" />
+                <subcommittee subcomcode="JU08" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX03</statedistrict>
+            <member-info>
+                <namelist>Johnson, Sam</namelist>
+                <bioguideID>J000174</bioguideID>
+                <lastname>Johnson</lastname>
+                <firstname>Sam</firstname>
+                <middlename/>
+                <sort-name>JOHNSON,SAM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Sam Johnson</official-name>
+                <formal-name>Mr. Sam Johnson of Texas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Plano</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2304</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4303</office-zip-suffix>
+                <phone>(202) 225-4201</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IT00" rank="2" />
+                <committee comcode="WM00" rank="2" />
+                <subcommittee subcomcode="WM01" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="WM02" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX04</statedistrict>
+            <member-info>
+                <namelist>Ratcliffe, John</namelist>
+                <bioguideID>R000601</bioguideID>
+                <lastname>Ratcliffe</lastname>
+                <firstname>John</firstname>
+                <middlename/>
+                <sort-name>RATCLIFFE,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John Ratcliffe</official-name>
+                <formal-name>Mr. Ratcliffe</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Heath</townname>
+                <office-building>CHOB</office-building>
+                <office-room>325</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4304</office-zip-suffix>
+                <phone>(202) 225-6673</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="12" />
+                <committee comcode="JU00" rank="19" />
+                <subcommittee subcomcode="HM08" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="HM09" rank="4" />
+                <subcommittee subcomcode="JU05" rank="6" />
+                <subcommittee subcomcode="JU08" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX05</statedistrict>
+            <member-info>
+                <namelist>Hensarling, Jeb</namelist>
+                <bioguideID>H001036</bioguideID>
+                <lastname>Hensarling</lastname>
+                <firstname>Jeb</firstname>
+                <middlename/>
+                <sort-name>HENSARLING,JEB</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jeb Hensarling</official-name>
+                <formal-name>Mr. Hensarling</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Dallas</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2228</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4305</office-zip-suffix>
+                <phone>(202) 225-3484</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="BA01" rank="15" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA04" rank="14" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA09" rank="12" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA15" rank="16" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA16" rank="17" leadership="Ex Officio" />
+                <subcommittee subcomcode="BA20" rank="13" leadership="Ex Officio" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX06</statedistrict>
+            <member-info>
+                <namelist>Barton, Joe</namelist>
+                <bioguideID>B000213</bioguideID>
+                <lastname>Barton</lastname>
+                <firstname>Joe</firstname>
+                <middlename/>
+                <sort-name>BARTON,JOE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Joe Barton</official-name>
+                <formal-name>Mr. Barton</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Ennis</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2107</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4306</office-zip-suffix>
+                <phone>(202) 225-2002</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="2" />
+                <subcommittee subcomcode="IF02" rank="3" />
+                <subcommittee subcomcode="IF03" rank="3" />
+                <subcommittee subcomcode="IF14" rank="3" />
+                <subcommittee subcomcode="IF18" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX07</statedistrict>
+            <member-info>
+                <namelist>Culberson, John</namelist>
+                <bioguideID>C001048</bioguideID>
+                <lastname>Culberson</lastname>
+                <firstname>John</firstname>
+                <middlename>Abney</middlename>
+                <sort-name>CULBERSON,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John Abney Culberson</official-name>
+                <formal-name>Mr. Culberson</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Houston</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2161</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4307</office-zip-suffix>
+                <phone>(202) 225-2571</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="6" />
+                <subcommittee subcomcode="AP15" rank="2" />
+                <subcommittee subcomcode="AP19" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AP20" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX08</statedistrict>
+            <member-info>
+                <namelist>Brady, Kevin</namelist>
+                <bioguideID>B000755</bioguideID>
+                <lastname>Brady</lastname>
+                <firstname>Kevin</firstname>
+                <middlename/>
+                <sort-name>BRADY,KEVIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kevin Brady</official-name>
+                <formal-name>Mr. Brady of Texas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>The Woodlands</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1011</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4308</office-zip-suffix>
+                <phone>(202) 225-4901</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IT00" rank="1" leadership="Chairman" />
+                <committee comcode="WM00" rank="1" leadership="Chairman" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX09</statedistrict>
+            <member-info>
+                <namelist>Green, Al</namelist>
+                <bioguideID>G000553</bioguideID>
+                <lastname>Green</lastname>
+                <firstname>Al</firstname>
+                <middlename/>
+                <sort-name>GREEN,AL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Al Green</official-name>
+                <formal-name>Mr. Al Green of Texas</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Houston</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2347</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4309</office-zip-suffix>
+                <phone>(202) 225-7508</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="10" />
+                <subcommittee subcomcode="BA09" rank="1" />
+                <subcommittee subcomcode="BA15" rank="6" />
+                <subcommittee subcomcode="BA20" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX10</statedistrict>
+            <member-info>
+                <namelist>McCaul, Michael</namelist>
+                <bioguideID>M001157</bioguideID>
+                <lastname>McCaul</lastname>
+                <firstname>Michael</firstname>
+                <middlename>T.</middlename>
+                <sort-name>MCCAUL,MICHAEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Michael T. McCaul</official-name>
+                <formal-name>Mr. McCaul</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Austin</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2001</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4310</office-zip-suffix>
+                <phone>(202) 225-2401</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="7" />
+                <committee comcode="HM00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="FA07" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX11</statedistrict>
+            <member-info>
+                <namelist>Conaway, K.</namelist>
+                <bioguideID>C001062</bioguideID>
+                <lastname>Conaway</lastname>
+                <firstname>K.</firstname>
+                <middlename>Michael</middlename>
+                <sort-name>CONAWAY,K.</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>K. Michael Conaway</official-name>
+                <formal-name>Mr. Conaway</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Midland</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2430</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4311</office-zip-suffix>
+                <phone>(202) 225-3605</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="1" leadership="Chairman" />
+                <committee comcode="AS00" rank="10" />
+                <committee comcode="IG00" rank="2" />
+                <subcommittee subcomcode="AS06" rank="2" />
+                <subcommittee subcomcode="AS28" rank="2" />
+                <subcommittee subcomcode="IG01" rank="2" />
+                <subcommittee subcomcode="IG02" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX12</statedistrict>
+            <member-info>
+                <namelist>Granger, Kay</namelist>
+                <bioguideID>G000377</bioguideID>
+                <lastname>Granger</lastname>
+                <firstname>Kay</firstname>
+                <middlename/>
+                <sort-name>GRANGER,KAY</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kay Granger</official-name>
+                <formal-name>Ms. Granger</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>12th</district>
+                <townname>Fort Worth</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1026</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4312</office-zip-suffix>
+                <phone>(202) 225-5071</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="4" />
+                <subcommittee subcomcode="AP02" rank="1" leadership="Chairwoman" />
+                <subcommittee subcomcode="AP04" rank="2" />
+                <subcommittee subcomcode="AP10" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX13</statedistrict>
+            <member-info>
+                <namelist>Thornberry, Mac</namelist>
+                <bioguideID>T000238</bioguideID>
+                <lastname>Thornberry</lastname>
+                <firstname>Mac</firstname>
+                <middlename/>
+                <sort-name>THORNBERRY,MAC</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mac Thornberry</official-name>
+                <formal-name>Mr. Thornberry</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>13th</district>
+                <townname>Clarendon</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2208</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4313</office-zip-suffix>
+                <phone>(202) 225-3706</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="1" leadership="Chairman" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX14</statedistrict>
+            <member-info>
+                <namelist>Weber, Randy</namelist>
+                <bioguideID>W000814</bioguideID>
+                <lastname>Weber</lastname>
+                <firstname>Randy</firstname>
+                <middlename>K.</middlename>
+                <sort-name>WEBER,RANDY</sort-name>
+                <suffix>Sr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Randy K. Weber, Sr.</official-name>
+                <formal-name>Mr. Weber of Texas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>14th</district>
+                <townname>Friendswood</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1708</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4314</office-zip-suffix>
+                <phone>(202) 225-2831</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="PW00" rank="26" />
+                <committee comcode="SY00" rank="9" />
+                <subcommittee subcomcode="PW02" rank="14" />
+                <subcommittee subcomcode="PW07" rank="6" />
+                <subcommittee subcomcode="PW14" rank="13" />
+                <subcommittee subcomcode="SY18" rank="5" />
+                <subcommittee subcomcode="SY20" rank="1" leadership="Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX15</statedistrict>
+            <member-info>
+                <namelist>Gonzalez, Vicente</namelist>
+                <bioguideID>G000581</bioguideID>
+                <lastname>Gonzalez</lastname>
+                <firstname>Vicente</firstname>
+                <middlename/>
+                <sort-name>GONZALEZ,VICENTE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Vicente Gonzalez</official-name>
+                <formal-name>Mr. Gonzalez of Texas</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>15th</district>
+                <townname>McAllen</townname>
+                <office-building>CHOB</office-building>
+                <office-room>113</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4315</office-zip-suffix>
+                <phone>(202) 225-2531</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="24" />
+                <subcommittee subcomcode="BA04" rank="10" />
+                <subcommittee subcomcode="BA09" rank="8" />
+                <subcommittee subcomcode="BA16" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX16</statedistrict>
+            <member-info>
+                <namelist>O'Rourke, Beto</namelist>
+                <bioguideID>O000170</bioguideID>
+                <lastname>O'Rourke</lastname>
+                <firstname>Beto</firstname>
+                <middlename/>
+                <sort-name>OROURKE,BETO</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Beto O'Rourke</official-name>
+                <formal-name>Mr. O'Rourke</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>16th</district>
+                <townname>El Paso</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1330</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4316</office-zip-suffix>
+                <phone>(202) 225-4831</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="14" />
+                <committee comcode="VR00" rank="5" />
+                <subcommittee subcomcode="AS26" rank="7" />
+                <subcommittee subcomcode="AS29" rank="5" />
+                <subcommittee subcomcode="VR03" rank="4" />
+                <subcommittee subcomcode="VR10" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX17</statedistrict>
+            <member-info>
+                <namelist>Flores, Bill</namelist>
+                <bioguideID>F000461</bioguideID>
+                <lastname>Flores</lastname>
+                <firstname>Bill</firstname>
+                <middlename/>
+                <sort-name>FLORES,BILL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bill Flores</official-name>
+                <formal-name>Mr. Flores</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>17th</district>
+                <townname>Bryan</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2440</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4317</office-zip-suffix>
+                <phone>(202) 225-6105</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="22" />
+                <subcommittee subcomcode="IF03" rank="14" />
+                <subcommittee subcomcode="IF16" rank="12" />
+                <subcommittee subcomcode="IF18" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX18</statedistrict>
+            <member-info>
+                <namelist>Jackson Lee, Sheila</namelist>
+                <bioguideID>J000032</bioguideID>
+                <lastname>Jackson Lee</lastname>
+                <firstname>Sheila</firstname>
+                <middlename/>
+                <sort-name>JACKSONLEE,SHEILA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Sheila Jackson Lee</official-name>
+                <formal-name>Ms. Jackson Lee</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>18th</district>
+                <townname>Houston</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2187</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4318</office-zip-suffix>
+                <phone>(202) 225-3816</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="13" />
+                <committee comcode="HM00" rank="2" />
+                <committee comcode="JU00" rank="4" />
+                <subcommittee subcomcode="HM05" rank="2" />
+                <subcommittee subcomcode="HM08" rank="2" />
+                <subcommittee subcomcode="JU01" rank="4" />
+                <subcommittee subcomcode="JU08" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX19</statedistrict>
+            <member-info>
+                <namelist>Arrington, Jodey</namelist>
+                <bioguideID>A000375</bioguideID>
+                <lastname>Arrington</lastname>
+                <firstname>Jodey</firstname>
+                <middlename>C.</middlename>
+                <sort-name>ARRINGTON,JODEY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Jodey C. Arrington</official-name>
+                <formal-name>Mr. Arrington</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>19th</district>
+                <townname>Lubbock</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1029</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4319</office-zip-suffix>
+                <phone>(202) 225-4005</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="26" />
+                <committee comcode="BU00" rank="21" />
+                <committee comcode="VR00" rank="9" />
+                <subcommittee subcomcode="AG03" rank="12" />
+                <subcommittee subcomcode="AG14" rank="8" />
+                <subcommittee subcomcode="AG16" rank="12" />
+                <subcommittee subcomcode="VR08" rank="5" />
+                <subcommittee subcomcode="VR10" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX20</statedistrict>
+            <member-info>
+                <namelist>Castro, Joaquin</namelist>
+                <bioguideID>C001091</bioguideID>
+                <lastname>Castro</lastname>
+                <firstname>Joaquin</firstname>
+                <middlename/>
+                <sort-name>CASTRO,JOAQUIN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Joaquin Castro</official-name>
+                <formal-name>Mr. Castro of Texas</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>20th</district>
+                <townname>San Antonio</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1221</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4320</office-zip-suffix>
+                <phone>(202) 225-3236</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="13" />
+                <committee comcode="IG00" rank="8" />
+                <subcommittee subcomcode="FA07" rank="2" />
+                <subcommittee subcomcode="FA16" rank="3" />
+                <subcommittee subcomcode="IG01" rank="3" />
+                <subcommittee subcomcode="IG04" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX21</statedistrict>
+            <member-info>
+                <namelist>Smith, Lamar</namelist>
+                <bioguideID>S000583</bioguideID>
+                <lastname>Smith</lastname>
+                <firstname>Lamar</firstname>
+                <middlename/>
+                <sort-name>SMITH,LAMAR</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Lamar Smith</official-name>
+                <formal-name>Mr. Smith of Texas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>21st</district>
+                <townname>San Antonio</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2409</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4321</office-zip-suffix>
+                <phone>(202) 225-4236</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="HM00" rank="2" />
+                <committee comcode="JU00" rank="3" />
+                <committee comcode="SY00" rank="1" leadership="Chair" />
+                <subcommittee subcomcode="HM11" rank="2" />
+                <subcommittee subcomcode="JU01" rank="3" />
+                <subcommittee subcomcode="JU03" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX22</statedistrict>
+            <member-info>
+                <namelist>Olson, Pete</namelist>
+                <bioguideID>O000168</bioguideID>
+                <lastname>Olson</lastname>
+                <firstname>Pete</firstname>
+                <middlename/>
+                <sort-name>OLSON,PETE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Pete Olson</official-name>
+                <formal-name>Mr. Olson</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>22nd</district>
+                <townname>Sugar Land</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2133</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4322</office-zip-suffix>
+                <phone>(202) 225-5951</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="14" />
+                <subcommittee subcomcode="IF03" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="IF16" rank="7" />
+                <subcommittee subcomcode="IF18" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX23</statedistrict>
+            <member-info>
+                <namelist>Hurd, Will</namelist>
+                <bioguideID>H001073</bioguideID>
+                <lastname>Hurd</lastname>
+                <firstname>Will</firstname>
+                <middlename/>
+                <sort-name>HURD,WILL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Will Hurd</official-name>
+                <formal-name>Mr. Hurd</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>23rd</district>
+                <townname>San Antonio</townname>
+                <office-building>CHOB</office-building>
+                <office-room>317</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4323</office-zip-suffix>
+                <phone>(202) 225-4511</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="21" />
+                <committee comcode="HM00" rank="10" />
+                <committee comcode="IG00" rank="13" />
+                <subcommittee subcomcode="GO25" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="HM05" rank="4" />
+                <subcommittee subcomcode="HM11" rank="6" />
+                <subcommittee subcomcode="IG03" rank="6" />
+                <subcommittee subcomcode="IG04" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX24</statedistrict>
+            <member-info>
+                <namelist>Marchant, Kenny</namelist>
+                <bioguideID>M001158</bioguideID>
+                <lastname>Marchant</lastname>
+                <firstname>Kenny</firstname>
+                <middlename/>
+                <sort-name>MARCHANT,KENNY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Kenny Marchant</official-name>
+                <formal-name>Mr. Marchant</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>24th</district>
+                <townname>Coppell</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2369</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4324</office-zip-suffix>
+                <phone>(202) 225-6605</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="SO00" rank="4" />
+                <committee comcode="WM00" rank="11" />
+                <subcommittee subcomcode="WM02" rank="8" />
+                <subcommittee subcomcode="WM05" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX25</statedistrict>
+            <member-info>
+                <namelist>Williams, Roger</namelist>
+                <bioguideID>W000816</bioguideID>
+                <lastname>Williams</lastname>
+                <firstname>Roger</firstname>
+                <middlename/>
+                <sort-name>WILLIAMS,ROGER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Roger Williams</official-name>
+                <formal-name>Mr. Williams</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>25th</district>
+                <townname>Austin</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1323</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4325</office-zip-suffix>
+                <phone>(202) 225-9896</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="20" />
+                <subcommittee subcomcode="BA01" rank="6" />
+                <subcommittee subcomcode="BA15" rank="10" />
+                <subcommittee subcomcode="BA20" rank="2" leadership="Vice Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX26</statedistrict>
+            <member-info>
+                <namelist>Burgess, Michael</namelist>
+                <bioguideID>B001248</bioguideID>
+                <lastname>Burgess</lastname>
+                <firstname>Michael</firstname>
+                <middlename>C.</middlename>
+                <sort-name>BURGESS,MICHAEL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Michael C. Burgess</official-name>
+                <formal-name>Mr. Burgess</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>26th</district>
+                <townname>Pilot Point</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2336</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4326</office-zip-suffix>
+                <phone>(202) 225-7772</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="6" />
+                <committee comcode="RU00" rank="4" />
+                <subcommittee subcomcode="IF02" rank="4" />
+                <subcommittee subcomcode="IF14" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="IF17" rank="4" />
+                <subcommittee subcomcode="RU02" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX27</statedistrict>
+            <member-info>
+                <namelist>Farenthold, Blake</namelist>
+                <bioguideID>F000460</bioguideID>
+                <lastname>Farenthold</lastname>
+                <firstname>Blake</firstname>
+                <middlename/>
+                <sort-name>FARENTHOLD,BLAKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Blake Farenthold</official-name>
+                <formal-name>Mr. Farenthold</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>27th</district>
+                <townname>Corpus Christi</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2331</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4327</office-zip-suffix>
+                <phone>(202) 225-7742</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="10" />
+                <committee comcode="JU00" rank="15" />
+                <committee comcode="PW00" rank="9" />
+                <subcommittee subcomcode="GO25" rank="5" />
+                <subcommittee subcomcode="GO28" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="JU03" rank="11" />
+                <subcommittee subcomcode="JU05" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="PW05" rank="6" />
+                <subcommittee subcomcode="PW12" rank="8" />
+                <subcommittee subcomcode="PW14" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX28</statedistrict>
+            <member-info>
+                <namelist>Cuellar, Henry</namelist>
+                <bioguideID>C001063</bioguideID>
+                <lastname>Cuellar</lastname>
+                <firstname>Henry</firstname>
+                <middlename/>
+                <sort-name>CUELLAR,HENRY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Henry Cuellar</official-name>
+                <formal-name>Mr. Cuellar</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>28th</district>
+                <townname>Laredo</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2209</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4328</office-zip-suffix>
+                <phone>(202) 225-1640</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="14" />
+                <subcommittee subcomcode="AP02" rank="6" />
+                <subcommittee subcomcode="AP15" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX29</statedistrict>
+            <member-info>
+                <namelist>Green, Gene</namelist>
+                <bioguideID>G000410</bioguideID>
+                <lastname>Green</lastname>
+                <firstname>Gene</firstname>
+                <middlename/>
+                <sort-name>GREEN,GENE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Gene Green</official-name>
+                <formal-name>Mr. Gene Green of Texas</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>29th</district>
+                <townname>Houston</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2470</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4329</office-zip-suffix>
+                <phone>(202) 225-1688</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="5" />
+                <subcommittee subcomcode="IF03" rank="4" />
+                <subcommittee subcomcode="IF14" rank="1" />
+                <subcommittee subcomcode="IF17" rank="9" />
+                <subcommittee subcomcode="IF18" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX30</statedistrict>
+            <member-info>
+                <namelist>Johnson, Eddie</namelist>
+                <bioguideID>J000126</bioguideID>
+                <lastname>Johnson</lastname>
+                <firstname>Eddie</firstname>
+                <middlename>Bernice</middlename>
+                <sort-name>JOHNSON,EDDIE</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Eddie Bernice Johnson</official-name>
+                <formal-name>Ms. Eddie Bernice Johnson of Texas</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>30th</district>
+                <townname>Dallas</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2468</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4330</office-zip-suffix>
+                <phone>(202) 225-8885</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="PW00" rank="4" />
+                <committee comcode="SY00" rank="1" />
+                <subcommittee subcomcode="PW02" rank="6" />
+                <subcommittee subcomcode="PW05" rank="2" />
+                <subcommittee subcomcode="PW12" rank="14" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX31</statedistrict>
+            <member-info>
+                <namelist>Carter, John</namelist>
+                <bioguideID>C001051</bioguideID>
+                <lastname>Carter</lastname>
+                <firstname>John</firstname>
+                <middlename>R.</middlename>
+                <sort-name>CARTER,JOHN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>John R. Carter</official-name>
+                <formal-name>Mr. Carter of Texas</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>31st</district>
+                <townname>Round Rock</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2110</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4331</office-zip-suffix>
+                <phone>(202) 225-3864</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="7" />
+                <subcommittee subcomcode="AP02" rank="7" />
+                <subcommittee subcomcode="AP15" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AP19" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX32</statedistrict>
+            <member-info>
+                <namelist>Sessions, Pete</namelist>
+                <bioguideID>S000250</bioguideID>
+                <lastname>Sessions</lastname>
+                <firstname>Pete</firstname>
+                <middlename/>
+                <sort-name>SESSIONS,PETE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Pete Sessions</official-name>
+                <formal-name>Mr. Sessions</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>32nd</district>
+                <townname>Dallas</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2233</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4332</office-zip-suffix>
+                <phone>(202) 225-2231</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="RU00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="RU04" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX33</statedistrict>
+            <member-info>
+                <namelist>Veasey, Marc</namelist>
+                <bioguideID>V000131</bioguideID>
+                <lastname>Veasey</lastname>
+                <firstname>Marc</firstname>
+                <middlename>A.</middlename>
+                <sort-name>VEASEY,MARC</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Marc A. Veasey</official-name>
+                <formal-name>Mr. Veasey</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>33rd</district>
+                <townname>Fort Worth</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1519</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4333</office-zip-suffix>
+                <phone>(202) 225-9897</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="12" />
+                <committee comcode="SY00" rank="7" />
+                <subcommittee subcomcode="AS25" rank="4" />
+                <subcommittee subcomcode="AS26" rank="5" />
+                <subcommittee subcomcode="SY16" rank="4" />
+                <subcommittee subcomcode="SY20" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX34</statedistrict>
+            <member-info>
+                <namelist>Vela, Filemon</namelist>
+                <bioguideID>V000132</bioguideID>
+                <lastname>Vela</lastname>
+                <firstname>Filemon</firstname>
+                <middlename/>
+                <sort-name>VELA,FILEMON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Filemon Vela</official-name>
+                <formal-name>Mr. Vela</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>34th</district>
+                <townname>Brownsville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>437</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4334</office-zip-suffix>
+                <phone>(202) 225-9901</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="7" />
+                <committee comcode="HM00" rank="7" />
+                <subcommittee subcomcode="AG15" rank="6" />
+                <subcommittee subcomcode="AG29" rank="2" />
+                <subcommittee subcomcode="HM11" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX35</statedistrict>
+            <member-info>
+                <namelist>Doggett, Lloyd</namelist>
+                <bioguideID>D000399</bioguideID>
+                <lastname>Doggett</lastname>
+                <firstname>Lloyd</firstname>
+                <middlename/>
+                <sort-name>DOGGETT,LLOYD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Lloyd Doggett</official-name>
+                <formal-name>Mr. Doggett</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>35th</district>
+                <townname>Austin</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2307</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4335</office-zip-suffix>
+                <phone>(202) 225-4865</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="4" />
+                <subcommittee subcomcode="WM03" rank="2" />
+                <subcommittee subcomcode="WM04" rank="3" />
+                <subcommittee subcomcode="WM05" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>TX36</statedistrict>
+            <member-info>
+                <namelist>Babin, Brian</namelist>
+                <bioguideID>B001291</bioguideID>
+                <lastname>Babin</lastname>
+                <firstname>Brian</firstname>
+                <middlename/>
+                <sort-name>BABIN,BRIAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Brian Babin</official-name>
+                <formal-name>Mr. Babin</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="TX">
+                    <state-fullname>Texas</state-fullname>
+                </state>
+                <district>36th</district>
+                <townname>Woodville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>316</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4336</office-zip-suffix>
+                <phone>(202) 225-1555</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="PW00" rank="21" />
+                <committee comcode="SY00" rank="11" />
+                <subcommittee subcomcode="PW02" rank="11" />
+                <subcommittee subcomcode="PW12" rank="17" />
+                <subcommittee subcomcode="PW14" rank="12" />
+                <subcommittee subcomcode="SY16" rank="1" leadership="Chair" />
+                <subcommittee subcomcode="SY18" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>UT01</statedistrict>
+            <member-info>
+                <namelist>Bishop, Rob</namelist>
+                <bioguideID>B001250</bioguideID>
+                <lastname>Bishop</lastname>
+                <firstname>Rob</firstname>
+                <middlename/>
+                <sort-name>BISHOP,ROB</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Rob Bishop</official-name>
+                <formal-name>Mr. Bishop of Utah</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="UT">
+                    <state-fullname>Utah</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Brigham City</townname>
+                <office-building>CHOB</office-building>
+                <office-room>123</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4401</office-zip-suffix>
+                <phone>(202) 225-0453</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="5" />
+                <committee comcode="II00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AS03" rank="2" />
+                <subcommittee subcomcode="AS25" rank="12" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>UT02</statedistrict>
+            <member-info>
+                <namelist>Stewart, Chris</namelist>
+                <bioguideID>S001192</bioguideID>
+                <lastname>Stewart</lastname>
+                <firstname>Chris</firstname>
+                <middlename/>
+                <sort-name>STEWART,CHRIS</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Chris Stewart</official-name>
+                <formal-name>Mr. Stewart</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="UT">
+                    <state-fullname>Utah</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Farmington</townname>
+                <office-building>CHOB</office-building>
+                <office-room>323</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4402</office-zip-suffix>
+                <phone>(202) 225-9730</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="24" />
+                <committee comcode="IG00" rank="9" />
+                <subcommittee subcomcode="AP04" rank="7" />
+                <subcommittee subcomcode="AP06" rank="5" leadership="Vice Chair" />
+                <subcommittee subcomcode="AP23" rank="5" />
+                <subcommittee subcomcode="IG01" rank="6" />
+                <subcommittee subcomcode="IG04" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>UT03</statedistrict>
+            <member-info>
+                <namelist>Chaffetz, Jason</namelist>
+                <bioguideID>C001076</bioguideID>
+                <lastname>Chaffetz</lastname>
+                <firstname>Jason</firstname>
+                <middlename/>
+                <sort-name>CHAFFETZ,JASON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jason Chaffetz</official-name>
+                <formal-name>Mr. Chaffetz</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="UT">
+                    <state-fullname>Utah</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Alpine</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2236</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4403</office-zip-suffix>
+                <phone>(202) 225-7751</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="1" leadership="Chairman" />
+                <committee comcode="JU00" rank="11" />
+                <subcommittee subcomcode="JU03" rank="8" />
+                <subcommittee subcomcode="JU08" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>UT04</statedistrict>
+            <member-info>
+                <namelist>Love, Mia</namelist>
+                <bioguideID>L000584</bioguideID>
+                <lastname>Love</lastname>
+                <firstname>Mia</firstname>
+                <middlename>B.</middlename>
+                <sort-name>LOVE,MIA</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mia B. Love</official-name>
+                <formal-name>Mrs. Love</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="UT">
+                    <state-fullname>Utah</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Saratoga Springs</townname>
+                <office-building>CHOB</office-building>
+                <office-room>217</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4404</office-zip-suffix>
+                <phone>(202) 225-3011</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="22" />
+                <subcommittee subcomcode="BA01" rank="8" />
+                <subcommittee subcomcode="BA15" rank="11" />
+                <subcommittee subcomcode="BA20" rank="6" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA01</statedistrict>
+            <member-info>
+                <namelist>Wittman, Robert</namelist>
+                <bioguideID>W000804</bioguideID>
+                <lastname>Wittman</lastname>
+                <firstname>Robert</firstname>
+                <middlename>J.</middlename>
+                <sort-name>WITTMAN,ROBERT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Robert J. Wittman</official-name>
+                <formal-name>Mr. Wittman</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Montross</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2055</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4601</office-zip-suffix>
+                <phone>(202) 225-4261</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="12" />
+                <committee comcode="II00" rank="5" />
+                <subcommittee subcomcode="AS25" rank="13" />
+                <subcommittee subcomcode="AS28" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="II06" rank="4" />
+                <subcommittee subcomcode="II13" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA02</statedistrict>
+            <member-info>
+                <namelist>Taylor, Scott</namelist>
+                <bioguideID>T000477</bioguideID>
+                <lastname>Taylor</lastname>
+                <firstname>Scott</firstname>
+                <middlename/>
+                <sort-name>TAYLOR,SCOTT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Scott Taylor</official-name>
+                <formal-name>Mr. Taylor</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Virginia Beach</townname>
+                <office-building>CHOB</office-building>
+                <office-room>412</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4602</office-zip-suffix>
+                <phone>(202) 225-4215</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="30" />
+                <subcommittee subcomcode="AP15" rank="7" />
+                <subcommittee subcomcode="AP18" rank="7" />
+                <subcommittee subcomcode="AP24" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA03</statedistrict>
+            <member-info>
+                <namelist>Scott, Robert</namelist>
+                <bioguideID>S000185</bioguideID>
+                <lastname>Scott</lastname>
+                <firstname>Robert</firstname>
+                <middlename>C. "Bobby"</middlename>
+                <sort-name>SCOTT,ROBERT</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Robert C. "Bobby" Scott</official-name>
+                <formal-name>Mr. Scott of Virginia</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Newport News</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1201</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4603</office-zip-suffix>
+                <phone>(202) 225-8351</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA04</statedistrict>
+            <member-info>
+                <namelist>McEachin, A.</namelist>
+                <bioguideID>M001200</bioguideID>
+                <lastname>McEachin</lastname>
+                <firstname>A.</firstname>
+                <middlename>Donald</middlename>
+                <sort-name>MCEACHIN,A.</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>A. Donald McEachin</official-name>
+                <formal-name>Mr. McEachin</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Henrico</townname>
+                <office-building>CHOB</office-building>
+                <office-room>314</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4604</office-zip-suffix>
+                <phone>(202) 225-6365</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="21" />
+                <committee comcode="II00" rank="16" />
+                <subcommittee subcomcode="AS03" rank="5" />
+                <subcommittee subcomcode="AS28" rank="9" />
+                <subcommittee subcomcode="II10" rank="7" />
+                <subcommittee subcomcode="II15" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA05</statedistrict>
+            <member-info>
+                <namelist>Garrett, Thomas</namelist>
+                <bioguideID>G000580</bioguideID>
+                <lastname>Garrett</lastname>
+                <firstname>Thomas</firstname>
+                <middlename>A.</middlename>
+                <sort-name>GARRETT,THOMAS</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Thomas A. Garrett, Jr.</official-name>
+                <formal-name>Mr. Garrett</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Scottsville</townname>
+                <office-building>CHOB</office-building>
+                <office-room>415</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4605</office-zip-suffix>
+                <phone>(202) 225-4711</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="ED00" rank="19" />
+                <committee comcode="FA00" rank="26" />
+                <committee comcode="HM00" rank="17" />
+                <subcommittee subcomcode="ED13" rank="11" />
+                <subcommittee subcomcode="ED14" rank="7" />
+                <subcommittee subcomcode="FA16" rank="5" />
+                <subcommittee subcomcode="FA18" rank="8" />
+                <subcommittee subcomcode="HM08" rank="6" />
+                <subcommittee subcomcode="HM12" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA06</statedistrict>
+            <member-info>
+                <namelist>Goodlatte, Bob</namelist>
+                <bioguideID>G000289</bioguideID>
+                <lastname>Goodlatte</lastname>
+                <firstname>Bob</firstname>
+                <middlename/>
+                <sort-name>GOODLATTE,BOB</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Bob Goodlatte</official-name>
+                <formal-name>Mr. Goodlatte</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Roanoke</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2309</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4606</office-zip-suffix>
+                <phone>(202) 225-5431</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="2" />
+                <committee comcode="JU00" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="AG22" rank="2" />
+                <subcommittee subcomcode="AG29" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA07</statedistrict>
+            <member-info>
+                <namelist>Brat, Dave</namelist>
+                <bioguideID>B001290</bioguideID>
+                <lastname>Brat</lastname>
+                <firstname>Dave</firstname>
+                <middlename/>
+                <sort-name>BRAT,DAVE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Dave Brat</official-name>
+                <formal-name>Mr. Brat</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Glen Allen</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1628</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4607</office-zip-suffix>
+                <phone>(202) 225-2815</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="9" />
+                <committee comcode="ED00" rank="12" />
+                <committee comcode="SM00" rank="4" />
+                <subcommittee subcomcode="ED10" rank="4" />
+                <subcommittee subcomcode="ED14" rank="6" />
+                <subcommittee subcomcode="SM26" rank="3" />
+                <subcommittee subcomcode="SM27" rank="1" leadership="Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA08</statedistrict>
+            <member-info>
+                <namelist>Beyer, Donald</namelist>
+                <bioguideID>B001292</bioguideID>
+                <lastname>Beyer</lastname>
+                <firstname>Donald</firstname>
+                <middlename>S.</middlename>
+                <sort-name>BEYER,DONALD</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Donald S. Beyer, Jr.</official-name>
+                <formal-name>Mr. Beyer</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Alexandria</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1119</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4608</office-zip-suffix>
+                <phone>(202) 225-4376</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="EC00" rank="10" />
+                <committee comcode="II00" rank="9" />
+                <committee comcode="SY00" rank="8" />
+                <subcommittee subcomcode="II06" rank="6" />
+                <subcommittee subcomcode="II13" rank="4" />
+                <subcommittee subcomcode="SY15" rank="6" />
+                <subcommittee subcomcode="SY16" rank="3" />
+                <subcommittee subcomcode="SY21" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA09</statedistrict>
+            <member-info>
+                <namelist>Griffith, H.</namelist>
+                <bioguideID>G000568</bioguideID>
+                <lastname>Griffith</lastname>
+                <firstname>H.</firstname>
+                <middlename>Morgan</middlename>
+                <sort-name>GRIFFITH,H.</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>H. Morgan Griffith</official-name>
+                <formal-name>Mr. Griffith</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Salem</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2202</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4609</office-zip-suffix>
+                <phone>(202) 225-3861</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="17" />
+                <subcommittee subcomcode="IF02" rank="2" leadership="Vice Chairman" />
+                <subcommittee subcomcode="IF03" rank="10" />
+                <subcommittee subcomcode="IF14" rank="10" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA10</statedistrict>
+            <member-info>
+                <namelist>Comstock, Barbara</namelist>
+                <bioguideID>C001105</bioguideID>
+                <lastname>Comstock</lastname>
+                <firstname>Barbara</firstname>
+                <middlename/>
+                <sort-name>COMSTOCK,BARBARA</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Barbara Comstock</official-name>
+                <formal-name>Mrs. Comstock</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>McLean</townname>
+                <office-building>CHOB</office-building>
+                <office-room>229</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4610</office-zip-suffix>
+                <phone>(202) 225-5136</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="EC00" rank="4" />
+                <committee comcode="HA00" rank="3" />
+                <committee comcode="PW00" rank="23" />
+                <committee comcode="SY00" rank="12" />
+                <subcommittee subcomcode="PW05" rank="17" />
+                <subcommittee subcomcode="PW12" rank="19" />
+                <subcommittee subcomcode="PW13" rank="3" />
+                <subcommittee subcomcode="SY15" rank="1" leadership="Chair" />
+                <subcommittee subcomcode="SY16" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VA11</statedistrict>
+            <member-info>
+                <namelist>Connolly, Gerald</namelist>
+                <bioguideID>C001078</bioguideID>
+                <lastname>Connolly</lastname>
+                <firstname>Gerald</firstname>
+                <middlename>E.</middlename>
+                <sort-name>CONNOLLY,GERALD</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Gerald E. Connolly</official-name>
+                <formal-name>Mr. Connolly</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="VA">
+                    <state-fullname>Virginia</state-fullname>
+                </state>
+                <district>11th</district>
+                <townname>Fairfax</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2238</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4611</office-zip-suffix>
+                <phone>(202) 225-1492</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="5" />
+                <committee comcode="GO00" rank="7" />
+                <subcommittee subcomcode="FA05" rank="4" />
+                <subcommittee subcomcode="FA13" rank="2" />
+                <subcommittee subcomcode="GO24" rank="1" />
+                <subcommittee subcomcode="GO25" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VI00</statedistrict>
+            <member-info>
+                <namelist>Plaskett, Stacey</namelist>
+                <bioguideID>P000610</bioguideID>
+                <lastname>Plaskett</lastname>
+                <firstname>Stacey</firstname>
+                <middlename>E.</middlename>
+                <sort-name>PLASKETT,STACEY</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Stacey E. Plaskett</official-name>
+                <formal-name>Ms. Plaskett</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="VI">
+                    <state-fullname>Virgin Islands</state-fullname>
+                </state>
+                <district>Delegate</district>
+                <townname>St. Croix</townname>
+                <office-building>CHOB</office-building>
+                <office-room>331</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>5500</office-zip-suffix>
+                <phone>(202) 225-1790</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AG00" rank="13" />
+                <committee comcode="GO00" rank="11" />
+                <subcommittee subcomcode="AG16" rank="7" />
+                <subcommittee subcomcode="AG22" rank="4" />
+                <subcommittee subcomcode="AG29" rank="4" />
+                <subcommittee subcomcode="GO27" rank="6" />
+                <subcommittee subcomcode="GO28" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>VT00</statedistrict>
+            <member-info>
+                <namelist>Welch, Peter</namelist>
+                <bioguideID>W000800</bioguideID>
+                <lastname>Welch</lastname>
+                <firstname>Peter</firstname>
+                <middlename/>
+                <sort-name>WELCH,PETER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Peter Welch</official-name>
+                <formal-name>Mr. Welch</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="VT">
+                    <state-fullname>Vermont</state-fullname>
+                </state>
+                <district>At Large</district>
+                <townname>Norwich</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2303</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4500</office-zip-suffix>
+                <phone>(202) 225-4115</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="GO00" rank="15" />
+                <committee comcode="IF00" rank="14" />
+                <subcommittee subcomcode="GO06" rank="3" />
+                <subcommittee subcomcode="IF03" rank="8" />
+                <subcommittee subcomcode="IF16" rank="2" />
+                <subcommittee subcomcode="IF17" rank="7" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA01</statedistrict>
+            <member-info>
+                <namelist>DelBene, Suzan</namelist>
+                <bioguideID>D000617</bioguideID>
+                <lastname>DelBene</lastname>
+                <firstname>Suzan</firstname>
+                <middlename>K.</middlename>
+                <sort-name>DELBENE,SUZAN</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Suzan K. DelBene</official-name>
+                <formal-name>Ms. DelBene</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Medina</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2442</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4701</office-zip-suffix>
+                <phone>(202) 225-6311</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="7" />
+                <committee comcode="WM00" rank="15" />
+                <subcommittee subcomcode="WM05" rank="5" />
+                <subcommittee subcomcode="WM06" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA02</statedistrict>
+            <member-info>
+                <namelist>Larsen, Rick</namelist>
+                <bioguideID>L000560</bioguideID>
+                <lastname>Larsen</lastname>
+                <firstname>Rick</firstname>
+                <middlename/>
+                <sort-name>LARSEN,RICK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Rick Larsen</official-name>
+                <formal-name>Mr. Larsen of Washington</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Everett</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2113</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4702</office-zip-suffix>
+                <phone>(202) 225-2605</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="5" />
+                <committee comcode="PW00" rank="6" />
+                <subcommittee subcomcode="AS26" rank="2" />
+                <subcommittee subcomcode="AS29" rank="3" />
+                <subcommittee subcomcode="PW05" rank="1" />
+                <subcommittee subcomcode="PW07" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA03</statedistrict>
+            <member-info>
+                <namelist>Herrera Beutler, Jaime</namelist>
+                <bioguideID>H001056</bioguideID>
+                <lastname>Herrera Beutler</lastname>
+                <firstname>Jaime</firstname>
+                <middlename/>
+                <sort-name>HERRERABEUTLER,JAIME</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Jaime Herrera Beutler</official-name>
+                <formal-name>Ms. Herrera Beutler</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Battle Ground</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1107</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4703</office-zip-suffix>
+                <phone>(202) 225-3536</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="18" />
+                <subcommittee subcomcode="AP07" rank="7" />
+                <subcommittee subcomcode="AP10" rank="6" />
+                <subcommittee subcomcode="AP23" rank="3" leadership="Vice Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA04</statedistrict>
+            <member-info>
+                <namelist>Newhouse, Dan</namelist>
+                <bioguideID>N000189</bioguideID>
+                <lastname>Newhouse</lastname>
+                <firstname>Dan</firstname>
+                <middlename/>
+                <sort-name>NEWHOUSE,DAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Dan Newhouse</official-name>
+                <formal-name>Mr. Newhouse</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Sunnyside</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1318</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4704</office-zip-suffix>
+                <phone>(202) 225-5816</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="28" />
+                <committee comcode="RU00" rank="7" />
+                <subcommittee subcomcode="AP10" rank="8" />
+                <subcommittee subcomcode="AP15" rank="6" />
+                <subcommittee subcomcode="AP24" rank="3" />
+                <subcommittee subcomcode="RU02" rank="4" />
+                <subcommittee subcomcode="RU04" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA05</statedistrict>
+            <member-info>
+                <namelist>McMorris Rodgers, Cathy</namelist>
+                <bioguideID>M001159</bioguideID>
+                <lastname>McMorris Rodgers</lastname>
+                <firstname>Cathy</firstname>
+                <middlename/>
+                <sort-name>MCMORRISRODGERS,CATHY</sort-name>
+                <suffix/>
+                <courtesy>Mrs.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Cathy McMorris Rodgers</official-name>
+                <formal-name>Mrs. McMorris Rodgers</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Spokane</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1314</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4705</office-zip-suffix>
+                <phone>(202) 225-2006</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="10" />
+                <subcommittee subcomcode="IF14" rank="8" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA06</statedistrict>
+            <member-info>
+                <namelist>Kilmer, Derek</namelist>
+                <bioguideID>K000381</bioguideID>
+                <lastname>Kilmer</lastname>
+                <firstname>Derek</firstname>
+                <middlename/>
+                <sort-name>KILMER,DEREK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Derek Kilmer</official-name>
+                <formal-name>Mr. Kilmer</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Gig Harbor</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1520</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4706</office-zip-suffix>
+                <phone>(202) 225-5916</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="17" />
+                <subcommittee subcomcode="AP06" rank="3" />
+                <subcommittee subcomcode="AP19" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA07</statedistrict>
+            <member-info>
+                <namelist>Jayapal, Pramila</namelist>
+                <bioguideID>J000298</bioguideID>
+                <lastname>Jayapal</lastname>
+                <firstname>Pramila</firstname>
+                <middlename/>
+                <sort-name>JAYAPAL,PRAMILA</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Pramila Jayapal</official-name>
+                <formal-name>Ms. Jayapal</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Seattle</townname>
+                <office-building>CHOB</office-building>
+                <office-room>319</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4707</office-zip-suffix>
+                <phone>(202) 225-3106</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="11" />
+                <committee comcode="JU00" rank="16" />
+                <subcommittee subcomcode="JU01" rank="3" />
+                <subcommittee subcomcode="JU05" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA08</statedistrict>
+            <member-info>
+                <namelist>Reichert, David</namelist>
+                <bioguideID>R000578</bioguideID>
+                <lastname>Reichert</lastname>
+                <firstname>David</firstname>
+                <middlename>G.</middlename>
+                <sort-name>REICHERT,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David G. Reichert</official-name>
+                <formal-name>Mr. Reichert</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Auburn</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1127</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4708</office-zip-suffix>
+                <phone>(202) 225-7761</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="5" />
+                <subcommittee subcomcode="WM03" rank="6" />
+                <subcommittee subcomcode="WM04" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="WM05" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA09</statedistrict>
+            <member-info>
+                <namelist>Smith, Adam</namelist>
+                <bioguideID>S000510</bioguideID>
+                <lastname>Smith</lastname>
+                <firstname>Adam</firstname>
+                <middlename/>
+                <sort-name>SMITH,ADAM</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Adam Smith</official-name>
+                <formal-name>Mr. Smith of Washington</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>9th</district>
+                <townname>Bellevue</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2264</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4709</office-zip-suffix>
+                <phone>(202) 225-8901</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="1" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WA10</statedistrict>
+            <member-info>
+                <namelist>Heck, Denny</namelist>
+                <bioguideID>H001064</bioguideID>
+                <lastname>Heck</lastname>
+                <firstname>Denny</firstname>
+                <middlename/>
+                <sort-name>HECK,DENNY</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Denny Heck</official-name>
+                <formal-name>Mr. Heck</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WA">
+                    <state-fullname>Washington</state-fullname>
+                </state>
+                <district>10th</district>
+                <townname>Olympia</townname>
+                <office-building>CHOB</office-building>
+                <office-room>425</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4710</office-zip-suffix>
+                <phone>(202) 225-9740</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="21" />
+                <committee comcode="IG00" rank="9" />
+                <subcommittee subcomcode="BA15" rank="9" />
+                <subcommittee subcomcode="BA20" rank="6" />
+                <subcommittee subcomcode="IG01" rank="4" />
+                <subcommittee subcomcode="IG04" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WI01</statedistrict>
+            <member-info>
+                <namelist>Ryan, Paul</namelist>
+                <bioguideID>R000570</bioguideID>
+                <lastname>Ryan</lastname>
+                <firstname>Paul</firstname>
+                <middlename>D.</middlename>
+                <sort-name>RYAN,PAUL</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Paul D. Ryan</official-name>
+                <formal-name>Mr. Ryan of Wisconsin</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WI">
+                    <state-fullname>Wisconsin</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Janesville</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1233</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4901</office-zip-suffix>
+                <phone>(202) 225-3031</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee rank="" /></committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WI02</statedistrict>
+            <member-info>
+                <namelist>Pocan, Mark</namelist>
+                <bioguideID>P000607</bioguideID>
+                <lastname>Pocan</lastname>
+                <firstname>Mark</firstname>
+                <middlename/>
+                <sort-name>POCAN,MARK</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Mark Pocan</official-name>
+                <formal-name>Mr. Pocan</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WI">
+                    <state-fullname>Wisconsin</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Madison</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1421</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4902</office-zip-suffix>
+                <phone>(202) 225-2906</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="20" />
+                <subcommittee subcomcode="AP01" rank="4" />
+                <subcommittee subcomcode="AP07" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WI03</statedistrict>
+            <member-info>
+                <namelist>Kind, Ron</namelist>
+                <bioguideID>K000188</bioguideID>
+                <lastname>Kind</lastname>
+                <firstname>Ron</firstname>
+                <middlename/>
+                <sort-name>KIND,RON</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Ron Kind</official-name>
+                <formal-name>Mr. Kind</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WI">
+                    <state-fullname>Wisconsin</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>La Crosse</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1502</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4903</office-zip-suffix>
+                <phone>(202) 225-5506</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="WM00" rank="8" />
+                <subcommittee subcomcode="WM02" rank="3" />
+                <subcommittee subcomcode="WM04" rank="2" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WI04</statedistrict>
+            <member-info>
+                <namelist>Moore, Gwen</namelist>
+                <bioguideID>M001160</bioguideID>
+                <lastname>Moore</lastname>
+                <firstname>Gwen</firstname>
+                <middlename/>
+                <sort-name>MOORE,GWEN</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Gwen Moore</official-name>
+                <formal-name>Ms. Moore</formal-name>
+                <party>D</party>
+                <caucus>D</caucus>
+                <state postal-code="WI">
+                    <state-fullname>Wisconsin</state-fullname>
+                </state>
+                <district>4th</district>
+                <townname>Milwaukee</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2252</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4904</office-zip-suffix>
+                <phone>(202) 225-4572</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="12" />
+                <subcommittee subcomcode="BA09" rank="6" />
+                <subcommittee subcomcode="BA15" rank="10" />
+                <subcommittee subcomcode="BA20" rank="1" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WI05</statedistrict>
+            <member-info>
+                <namelist>Sensenbrenner, F.</namelist>
+                <bioguideID>S000244</bioguideID>
+                <lastname>Sensenbrenner</lastname>
+                <firstname>F.</firstname>
+                <middlename>James</middlename>
+                <sort-name>SENSENBRENNER,F.</sort-name>
+                <suffix>Jr.</suffix>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>F. James Sensenbrenner, Jr.</official-name>
+                <formal-name>Mr. Sensenbrenner</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WI">
+                    <state-fullname>Wisconsin</state-fullname>
+                </state>
+                <district>5th</district>
+                <townname>Menomonee Falls</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2449</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4905</office-zip-suffix>
+                <phone>(202) 225-5101</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="FA00" rank="21" />
+                <committee comcode="JU00" rank="2" />
+                <subcommittee subcomcode="FA14" rank="6" />
+                <subcommittee subcomcode="FA16" rank="4" />
+                <subcommittee subcomcode="JU01" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="JU08" rank="3" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WI06</statedistrict>
+            <member-info>
+                <namelist>Grothman, Glenn</namelist>
+                <bioguideID>G000576</bioguideID>
+                <lastname>Grothman</lastname>
+                <firstname>Glenn</firstname>
+                <middlename/>
+                <sort-name>GROTHMAN,GLENN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Glenn Grothman</official-name>
+                <formal-name>Mr. Grothman</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WI">
+                    <state-fullname>Wisconsin</state-fullname>
+                </state>
+                <district>6th</district>
+                <townname>Glenbeulah</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1217</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4906</office-zip-suffix>
+                <phone>(202) 225-2476</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BU00" rank="10" />
+                <committee comcode="ED00" rank="13" />
+                <committee comcode="GO00" rank="20" />
+                <subcommittee subcomcode="ED10" rank="5" />
+                <subcommittee subcomcode="ED13" rank="6" />
+                <subcommittee subcomcode="GO27" rank="7" />
+                <subcommittee subcomcode="GO29" rank="2" leadership="Vice Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WI07</statedistrict>
+            <member-info>
+                <namelist>Duffy, Sean</namelist>
+                <bioguideID>D000614</bioguideID>
+                <lastname>Duffy</lastname>
+                <firstname>Sean</firstname>
+                <middlename>P.</middlename>
+                <sort-name>DUFFY,SEAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Sean P. Duffy</official-name>
+                <formal-name>Mr. Duffy</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WI">
+                    <state-fullname>Wisconsin</state-fullname>
+                </state>
+                <district>7th</district>
+                <townname>Wausau</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2330</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4907</office-zip-suffix>
+                <phone>(202) 225-3365</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="10" />
+                <subcommittee subcomcode="BA04" rank="1" leadership="Chairman" />
+                <subcommittee subcomcode="BA16" rank="5" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WI08</statedistrict>
+            <member-info>
+                <namelist>Gallagher, Mike</namelist>
+                <bioguideID>G000579</bioguideID>
+                <lastname>Gallagher</lastname>
+                <firstname>Mike</firstname>
+                <middlename/>
+                <sort-name>GALLAGHER,MIKE</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Mike Gallagher</official-name>
+                <formal-name>Mr. Gallagher</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WI">
+                    <state-fullname>Wisconsin</state-fullname>
+                </state>
+                <district>8th</district>
+                <townname>Green Bay</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1007</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4908</office-zip-suffix>
+                <phone>(202) 225-5665</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="30" />
+                <committee comcode="HM00" rank="14" />
+                <subcommittee subcomcode="AS03" rank="11" />
+                <subcommittee subcomcode="AS28" rank="6" />
+                <subcommittee subcomcode="HM05" rank="5" />
+                <subcommittee subcomcode="HM08" rank="4" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WV01</statedistrict>
+            <member-info>
+                <namelist>McKinley, David</namelist>
+                <bioguideID>M001180</bioguideID>
+                <lastname>McKinley</lastname>
+                <firstname>David</firstname>
+                <middlename>B.</middlename>
+                <sort-name>MCKINLEY,DAVID</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>David B. McKinley</official-name>
+                <formal-name>Mr. McKinley</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WV">
+                    <state-fullname>West Virginia</state-fullname>
+                </state>
+                <district>1st</district>
+                <townname>Wheeling</townname>
+                <office-building>RHOB</office-building>
+                <office-room>2239</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4801</office-zip-suffix>
+                <phone>(202) 225-4172</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="IF00" rank="15" />
+                <subcommittee subcomcode="IF03" rank="8" />
+                <subcommittee subcomcode="IF17" rank="7" />
+                <subcommittee subcomcode="IF18" rank="2" leadership="Vice Chairman" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WV02</statedistrict>
+            <member-info>
+                <namelist>Mooney, Alexander</namelist>
+                <bioguideID>M001195</bioguideID>
+                <lastname>Mooney</lastname>
+                <firstname>Alexander</firstname>
+                <middlename>X.</middlename>
+                <sort-name>MOONEY,ALEXANDER</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Alexander X. Mooney</official-name>
+                <formal-name>Mr. Mooney of West Virginia</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WV">
+                    <state-fullname>West Virginia</state-fullname>
+                </state>
+                <district>2nd</district>
+                <townname>Charles Town</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1232</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4802</office-zip-suffix>
+                <phone>(202) 225-2711</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="BA00" rank="28" />
+                <subcommittee subcomcode="BA16" rank="12" />
+                <subcommittee subcomcode="BA20" rank="9" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WV03</statedistrict>
+            <member-info>
+                <namelist>Jenkins, Evan</namelist>
+                <bioguideID>J000297</bioguideID>
+                <lastname>Jenkins</lastname>
+                <firstname>Evan</firstname>
+                <middlename>H.</middlename>
+                <sort-name>JENKINS,EVAN</sort-name>
+                <suffix/>
+                <courtesy>Mr.</courtesy>
+                <prior-congress>114</prior-congress>
+                <official-name>Evan H. Jenkins</official-name>
+                <formal-name>Mr. Jenkins of West Virginia</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WV">
+                    <state-fullname>West Virginia</state-fullname>
+                </state>
+                <district>3rd</district>
+                <townname>Huntington</townname>
+                <office-building>LHOB</office-building>
+                <office-room>1609</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>4803</office-zip-suffix>
+                <phone>(202) 225-3452</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AP00" rank="26" />
+                <subcommittee subcomcode="AP06" rank="7" />
+                <subcommittee subcomcode="AP18" rank="6" />
+                <subcommittee subcomcode="AP19" rank="7" leadership="Vice Chair" />
+            </committee-assignments>
+        </member>
+        <member>
+            <statedistrict>WY00</statedistrict>
+            <member-info>
+                <namelist>Cheney, Liz</namelist>
+                <bioguideID>C001109</bioguideID>
+                <lastname>Cheney</lastname>
+                <firstname>Liz</firstname>
+                <middlename/>
+                <sort-name>CHENEY,LIZ</sort-name>
+                <suffix/>
+                <courtesy>Ms.</courtesy>
+                <prior-congress>0</prior-congress>
+                <official-name>Liz Cheney</official-name>
+                <formal-name>Ms. Cheney</formal-name>
+                <party>R</party>
+                <caucus>R</caucus>
+                <state postal-code="WY">
+                    <state-fullname>Wyoming</state-fullname>
+                </state>
+                <district>At Large</district>
+                <townname>Wilson</townname>
+                <office-building>CHOB</office-building>
+                <office-room>416</office-room>
+                <office-zip>20515</office-zip>
+                <office-zip-suffix>5000</office-zip-suffix>
+                <phone>(202) 225-2311</phone>
+                <elected-date date="20161108">November 8, 2016</elected-date>
+                <sworn-date date="20170103">January 3, 2017</sworn-date>
+            </member-info>
+            <committee-assignments>
+                <committee comcode="AS00" rank="34" />
+                <committee comcode="II00" rank="23" />
+                <committee comcode="RU00" rank="9" />
+                <subcommittee subcomcode="AS06" rank="5" />
+                <subcommittee subcomcode="AS26" rank="5" leadership="Vice Chair" />
+                <subcommittee subcomcode="II06" rank="13" />
+                <subcommittee subcomcode="II10" rank="12" />
+                <subcommittee subcomcode="RU04" rank="4" />
+            </committee-assignments>
+        </member>
+    </members>
+    <committees>
+        <committee type="standing" comcode="AG00" com-room="1301" com-header-text="The chairman and ranking minority member are ex officio members of all subcommittees." com-zip="20515" com-zip-suffix="6001" com-building-code="LHOB" com-phone="225-2171">
+            <committee-fullname>Committee on Agriculture</committee-fullname>
+            <ratio>
+                <majority>26</majority>
+                <minority>20</minority>
+            </ratio>
+            <subcommittee subcomcode="AG03" subcom-room="1301" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-2171">
+                <subcommittee-fullname>Nutrition</subcommittee-fullname>
+                <ratio>
+                    <majority>12</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AG14" subcom-room="1301" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-2171">
+                <subcommittee-fullname>Biotechnology, Horticulture, and Research</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AG15" subcom-room="1301" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-2171">
+                <subcommittee-fullname>Conservation and Forestry</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AG16" subcom-room="1301" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-2171">
+                <subcommittee-fullname>General Farm Commodities and Risk Management</subcommittee-fullname>
+                <ratio>
+                    <majority>12</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AG22" subcom-room="1301" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-2171">
+                <subcommittee-fullname>Commodity Exchanges, Energy, and Credit</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AG29" subcom-room="1301" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-2171">
+                <subcommittee-fullname>Livestock and Foreign Agriculture</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="AP00" com-room="H305" com-header-text="The chairman and ranking minority member are authorized to sit as  members of all subcommittees." com-zip="20515" com-zip-suffix="6015" com-building-code="C" com-phone="225-2771">
+            <committee-fullname>Committee on Appropriations</committee-fullname>
+            <ratio>
+                <majority>30</majority>
+                <minority>22</minority>
+            </ratio>
+            <subcommittee subcomcode="AP01" subcom-room="2362A" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-2638">
+                <subcommittee-fullname>Agriculture, Rural Development, Food and Drug Administration, and Related Agencies</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP02" subcom-room="H405" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="C" subcom-phone="225-2847">
+                <subcommittee-fullname>Defense</subcommittee-fullname>
+                <ratio>
+                    <majority>10</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP04" subcom-room="HT2" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="C" subcom-phone="225-2041">
+                <subcommittee-fullname>State, Foreign Operations, and Related Programs</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP06" subcom-room="2007" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-3081">
+                <subcommittee-fullname>Interior, Environment, and Related Agencies</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP07" subcom-room="2358B" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-3508">
+                <subcommittee-fullname>Labor, Health and Human Services, Education, and Related Agencies</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP10" subcom-room="2362B" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-3421">
+                <subcommittee-fullname>Energy and Water Development, and Related Agencies</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP15" subcom-room="2006" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5834">
+                <subcommittee-fullname>Homeland Security</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP18" subcom-room="HVC227" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="C" subcom-phone="225-3047">
+                <subcommittee-fullname>Military Construction, Veterans Affairs and Related Agencies</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP19" subcom-room="H310" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="C" subcom-phone="225-3351">
+                <subcommittee-fullname>Commerce, Justice, Science, and Related Agencies</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP20" subcom-room="2358A" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-2141">
+                <subcommittee-fullname>Transportation, Housing and Urban Development, and Related Agencies</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP23" subcom-room="2000" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-7245">
+                <subcommittee-fullname>Financial Services and General Government</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AP24" subcom-room="HT2" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="C" subcom-phone="226-7252">
+                <subcommittee-fullname>Legislative Branch</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>3</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="AS00" com-room="2216" com-zip="20515" com-zip-suffix="6035" com-building-code="RHOB" com-phone="225-4151">
+            <committee-fullname>Committee on Armed Services</committee-fullname>
+            <ratio>
+                <majority>34</majority>
+                <minority>28</minority>
+            </ratio>
+            <subcommittee subcomcode="AS02" subcom-room="2340" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-7560">
+                <subcommittee-fullname>Military Personnel</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AS03" subcom-room="2340" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="226-8979">
+                <subcommittee-fullname>Readiness</subcommittee-fullname>
+                <ratio>
+                    <majority>11</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AS06" subcom-room="2119" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="226-5048">
+                <subcommittee-fullname>Oversight and Investigations</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AS25" subcom-room="2340" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-4440">
+                <subcommittee-fullname>Tactical Air and Land Forces</subcommittee-fullname>
+                <ratio>
+                    <majority>14</majority>
+                    <minority>11</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AS26" subcom-room="2340" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="226-2843">
+                <subcommittee-fullname>Emerging Threats and Capabilities</subcommittee-fullname>
+                <ratio>
+                    <majority>10</majority>
+                    <minority>8</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AS28" subcom-room="2340" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="226-2211">
+                <subcommittee-fullname>Seapower and Projection Forces</subcommittee-fullname>
+                <ratio>
+                    <majority>11</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="AS29" subcom-room="2340" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-1967">
+                <subcommittee-fullname>Strategic Forces</subcommittee-fullname>
+                <ratio>
+                    <majority>10</majority>
+                    <minority>8</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="BA00" com-room="2129" com-zip="20515" com-zip-suffix="6050" com-building-code="RHOB" com-phone="225-7502">
+            <committee-fullname>Committee on Financial Services</committee-fullname>
+            <ratio>
+                <majority>34</majority>
+                <minority>26</minority>
+            </ratio>
+            <subcommittee subcomcode="BA01" subcom-room="2129" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-7502">
+                <subcommittee-fullname>Terrorism and Illicit Finance</subcommittee-fullname>
+                <ratio>
+                    <majority>15</majority>
+                    <minority>12</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="BA04" subcom-room="2129" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-7502">
+                <subcommittee-fullname>Housing and Insurance</subcommittee-fullname>
+                <ratio>
+                    <majority>14</majority>
+                    <minority>11</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="BA09" subcom-room="2129" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-7502">
+                <subcommittee-fullname>Oversight and Investigations</subcommittee-fullname>
+                <ratio>
+                    <majority>13</majority>
+                    <minority>10</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="BA15" subcom-room="2129" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-7502">
+                <subcommittee-fullname>Financial Institutions and Consumer Credit</subcommittee-fullname>
+                <ratio>
+                    <majority>16</majority>
+                    <minority>12</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="BA16" subcom-room="2129" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-7502">
+                <subcommittee-fullname>Capital Markets, Securities, and Investment</subcommittee-fullname>
+                <ratio>
+                    <majority>17</majority>
+                    <minority>13</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="BA20" subcom-room="2129" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-7502">
+                <subcommittee-fullname>Monetary Policy and Trade</subcommittee-fullname>
+                <ratio>
+                    <majority>13</majority>
+                    <minority>10</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="BU00" com-room="B234" com-zip="20515" com-zip-suffix="6065" com-building-code="LHOB" com-phone="226-7270">
+            <committee-fullname>Committee on the Budget</committee-fullname>
+            <ratio>
+                <majority>22</majority>
+                <minority>14</minority>
+            </ratio>
+        </committee>
+        <committee type="standing" comcode="ED00" com-room="2176" com-header-text="The chairman and the ranking minority member are ex officio, non-voting members of all subcommittees to which they are not assigned." com-zip="20515" com-zip-suffix="6100" com-building-code="RHOB" com-phone="225-4527">
+            <committee-fullname>Committee on Education and the Workforce</committee-fullname>
+            <ratio>
+                <majority>23</majority>
+                <minority>17</minority>
+            </ratio>
+            <subcommittee subcomcode="ED02" subcom-room="2176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-4527">
+                <subcommittee-fullname>Health, Employment, Labor, and Pensions</subcommittee-fullname>
+                <ratio>
+                    <majority>12</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="ED10" subcom-room="2176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-4527">
+                <subcommittee-fullname>Workforce Protections</subcommittee-fullname>
+                <ratio>
+                    <majority>9</majority>
+                    <minority>7</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="ED13" subcom-room="2176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-4527">
+                <subcommittee-fullname>Higher Education and Workforce Development</subcommittee-fullname>
+                <ratio>
+                    <majority>13</majority>
+                    <minority>10</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="ED14" subcom-room="2176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-4527">
+                <subcommittee-fullname>Early Childhood, Elementary, and Secondary Education</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="FA00" com-room="2170" com-header-text="The chairman and ranking minority member may attend the meetings and participate in the activities of all subcommittees except for voting and being counted for a quorum." com-zip="20515" com-zip-suffix="6128" com-building-code="RHOB" com-phone="225-5021">
+            <committee-fullname>Committee on Foreign Affairs</committee-fullname>
+            <ratio>
+                <majority>26</majority>
+                <minority>21</minority>
+            </ratio>
+            <subcommittee subcomcode="FA05" subcom-room="5190" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="226-7825">
+                <subcommittee-fullname>Asia and the Pacific</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="FA07" subcom-room="5100" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="226-9980">
+                <subcommittee-fullname>The Western Hemisphere</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="FA13" subcom-room="5220" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="225-3345">
+                <subcommittee-fullname>The Middle East and North Africa</subcommittee-fullname>
+                <ratio>
+                    <majority>12</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="FA14" subcom-room="5210" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="226-6434">
+                <subcommittee-fullname>Europe, Eurasia, and Emerging Threats</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="FA16" subcom-room="5210" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="226-7812">
+                <subcommittee-fullname>Africa, Global Health, Global Human Rights, and International Organizations</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="FA18" subcom-room="5100" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="226-1500">
+                <subcommittee-fullname>Terrorism, Nonproliferation, and Trade</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="GO00" com-room="2157" com-header-text="The chairman and ranking minority member are ex officio members of all subcommittees." com-zip="20515" com-zip-suffix="6143" com-building-code="RHOB" com-phone="225-5074">
+            <committee-fullname>Committee on Oversight and Government Reform</committee-fullname>
+            <ratio>
+                <majority>24</majority>
+                <minority>18</minority>
+            </ratio>
+            <subcommittee subcomcode="GO06" subcom-room="2157" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5074">
+                <subcommittee-fullname>National Security</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>7</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="GO24" subcom-room="2157" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5074">
+                <subcommittee-fullname>Government Operations</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="GO25" subcom-room="2157" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5074">
+                <subcommittee-fullname>Information Technology</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="GO27" subcom-room="2157" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5074">
+                <subcommittee-fullname>Health Care, Benefits, and Administrative Rules</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="GO28" subcom-room="2157" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5074">
+                <subcommittee-fullname>The Interior, Energy and Environment</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="GO29" subcom-room="2157" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5074">
+                <subcommittee-fullname>Intergovernmental Affairs</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="HA00" com-room="1309" com-zip="20515" com-zip-suffix="6157" com-building-code="LHOB" com-phone="225-8281">
+            <committee-fullname>Committee on House Administration</committee-fullname>
+            <ratio>
+                <majority>6</majority>
+                <minority>3</minority>
+            </ratio>
+        </committee>
+        <committee type="standing" comcode="HM00" com-room="176" com-header-text="The chairman and ranking minority member are non-voting ex officio members of all subcommittees on which they do not hold a regular  assignment." com-zip="20515" com-zip-suffix="6480" com-building-code="FHOB" com-phone="226-8417">
+            <committee-fullname>Committee on Homeland Security</committee-fullname>
+            <ratio>
+                <majority>18</majority>
+                <minority>12</minority>
+            </ratio>
+            <subcommittee subcomcode="HM05" subcom-room="176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="226-8417">
+                <subcommittee-fullname>Counterterrorism and Intelligence</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>3</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="HM07" subcom-room="176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="226-8417">
+                <subcommittee-fullname>Transportation and Protective Security</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>3</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="HM08" subcom-room="176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="226-8417">
+                <subcommittee-fullname>Cybersecurity and Infrastructure Protection</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="HM09" subcom-room="176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="226-8417">
+                <subcommittee-fullname>Oversight and Management Efficiency</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>3</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="HM11" subcom-room="176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="226-8417">
+                <subcommittee-fullname>Border and Maritime Security</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="HM12" subcom-room="176" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="226-8417">
+                <subcommittee-fullname>Emergency Preparedness, Response, and Communications</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>3</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="IF00" com-room="2125" com-header-text="The chairman and ranking minority member are ex officio members, with vote, of all subcommittees." com-zip="20515" com-zip-suffix="6115" com-building-code="RHOB" com-phone="225-2927">
+            <committee-fullname>Committee on Energy and Commerce</committee-fullname>
+            <ratio>
+                <majority>31</majority>
+                <minority>24</minority>
+            </ratio>
+            <subcommittee subcomcode="IF02" subcom-room="2125" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-2927">
+                <subcommittee-fullname>Oversight and Investigations</subcommittee-fullname>
+                <ratio>
+                    <majority>10</majority>
+                    <minority>7</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="IF03" subcom-room="2125" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-2927">
+                <subcommittee-fullname>Energy</subcommittee-fullname>
+                <ratio>
+                    <majority>18</majority>
+                    <minority>13</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="IF14" subcom-room="2125" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-2927">
+                <subcommittee-fullname>Health</subcommittee-fullname>
+                <ratio>
+                    <majority>18</majority>
+                    <minority>13</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="IF16" subcom-room="2125" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-2927">
+                <subcommittee-fullname>Communications and Technology</subcommittee-fullname>
+                <ratio>
+                    <majority>17</majority>
+                    <minority>12</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="IF17" subcom-room="2125" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-2927">
+                <subcommittee-fullname>Digital Commerce and Consumer Protection</subcommittee-fullname>
+                <ratio>
+                    <majority>13</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="IF18" subcom-room="2125" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-2927">
+                <subcommittee-fullname>Environment</subcommittee-fullname>
+                <ratio>
+                    <majority>13</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="II00" com-room="1324" com-header-text="The chairman and ranking minority member are non-voting ex officio members of all subcommittees on which they do not hold a regular  assignment." com-zip="20515" com-zip-suffix="6201" com-building-code="LHOB" com-phone="225-2761">
+            <committee-fullname>Committee on Natural Resources</committee-fullname>
+            <ratio>
+                <majority>25</majority>
+                <minority>18</minority>
+            </ratio>
+            <subcommittee subcomcode="II06" subcom-room="1522" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-9297">
+                <subcommittee-fullname>Energy and Mineral Resources</subcommittee-fullname>
+                <ratio>
+                    <majority>13</majority>
+                    <minority>10</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="II10" subcom-room="1332" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="226-7736">
+                <subcommittee-fullname>Federal Lands</subcommittee-fullname>
+                <ratio>
+                    <majority>12</majority>
+                    <minority>9</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="II13" subcom-room="4120" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="225-8331">
+                <subcommittee-fullname>Water, Power and Oceans</subcommittee-fullname>
+                <ratio>
+                    <majority>11</majority>
+                    <minority>8</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="II15" subcom-room="4170" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="225-7107">
+                <subcommittee-fullname>Oversight and Investigations</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="II24" subcom-room="4450" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="226-9725">
+                <subcommittee-fullname>Indian, Insular and Alaska Native Affairs</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="JU00" com-room="2138" com-zip="20515" com-zip-suffix="6216" com-building-code="RHOB" com-phone="225-3951">
+            <committee-fullname>Committee on the Judiciary</committee-fullname>
+            <ratio>
+                <majority>24</majority>
+                <minority>17</minority>
+            </ratio>
+            <subcommittee subcomcode="JU01" subcom-room="6320" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="225-3926">
+                <subcommittee-fullname>Immigration and Border Security</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="JU03" subcom-room="6310" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="225-5741">
+                <subcommittee-fullname>Courts, Intellectual Property, and the Internet</subcommittee-fullname>
+                <ratio>
+                    <majority>14</majority>
+                    <minority>12</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="JU05" subcom-room="6240" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="226-7680">
+                <subcommittee-fullname>Regulatory Reform, Commercial and Antitrust Law</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="JU08" subcom-room="6340" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="225-5727">
+                <subcommittee-fullname>Crime, Terrorism, Homeland Security, and Investigations</subcommittee-fullname>
+                <ratio>
+                    <majority>10</majority>
+                    <minority>7</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="JU10" subcom-room="362" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="225-2825">
+                <subcommittee-fullname>The Constitution and Civil Justice</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>3</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="PW00" com-room="2251" com-header-text="The chairman and ranking minority member are ex officio members, with vote, of all subcommittees." com-zip="20515" com-zip-suffix="6256" com-building-code="RHOB" com-phone="225-9446">
+            <committee-fullname>Committee on Transportation and Infrastructure</committee-fullname>
+            <ratio>
+                <majority>34</majority>
+                <minority>27</minority>
+            </ratio>
+            <subcommittee subcomcode="PW02" subcom-room="585" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="225-4360">
+                <subcommittee-fullname>Water Resources and Environment</subcommittee-fullname>
+                <ratio>
+                    <majority>17</majority>
+                    <minority>13</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="PW05" subcom-room="2251" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="226-3220">
+                <subcommittee-fullname>Aviation</subcommittee-fullname>
+                <ratio>
+                    <majority>21</majority>
+                    <minority>16</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="PW07" subcom-room="507" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="226-3552">
+                <subcommittee-fullname>Coast Guard and Maritime Transportation</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="PW12" subcom-room="2251" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-6715">
+                <subcommittee-fullname>Highways and Transit</subcommittee-fullname>
+                <ratio>
+                    <majority>27</majority>
+                    <minority>21</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="PW13" subcom-room="586" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="FHOB" subcom-phone="225-3014">
+                <subcommittee-fullname>Economic Development, Public Buildings, and Emergency Management</subcommittee-fullname>
+                <ratio>
+                    <majority>8</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="PW14" subcom-room="2029" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="226-0727">
+                <subcommittee-fullname>Railroads, Pipelines, and Hazardous Materials</subcommittee-fullname>
+                <ratio>
+                    <majority>18</majority>
+                    <minority>14</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="RU00" com-room="H312" com-zip="20515" com-zip-suffix="6269" com-building-code="C" com-phone="225-9191">
+            <committee-fullname>Committee on Rules</committee-fullname>
+            <ratio>
+                <majority>9</majority>
+                <minority>4</minority>
+            </ratio>
+            <subcommittee subcomcode="RU02" subcom-room="H312" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="C" subcom-phone="225-9191">
+                <subcommittee-fullname>Legislative and Budget Process</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>2</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="RU04" subcom-room="H312" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="C" subcom-phone="225-9191">
+                <subcommittee-fullname>Rules and Organization of the House</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>2</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="SM00" com-room="2361" com-zip="20515" com-zip-suffix="6315" com-building-code="RHOB" com-phone="225-5821">
+            <committee-fullname>Committee on Small Business</committee-fullname>
+            <ratio>
+                <majority>14</majority>
+                <minority>10</minority>
+            </ratio>
+            <subcommittee subcomcode="SM23" subcom-room="2361" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5821">
+                <subcommittee-fullname>Contracting and Workforce</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="SM24" subcom-room="2361" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5821">
+                <subcommittee-fullname>Investigations, Oversight and Regulations</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="SM25" subcom-room="2361" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5821">
+                <subcommittee-fullname>Agriculture, Energy and Trade</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="SM26" subcom-room="2361" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5821">
+                <subcommittee-fullname>Health and Technology</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="SM27" subcom-room="2361" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-5821">
+                <subcommittee-fullname>Economic Growth, Tax and Capital Access</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="SO00" com-room="1015" com-zip="20515" com-zip-suffix="6328" com-building-code="LHOB" com-phone="225-7103">
+            <committee-fullname>Committee on Ethics</committee-fullname>
+            <ratio>
+                <majority>5</majority>
+                <minority>5</minority>
+            </ratio>
+        </committee>
+        <committee type="standing" comcode="SY00" com-room="2321" com-header-text="The chairman and ranking minority member are ex officio members, without vote, of all subcommittees." com-zip="20515" com-zip-suffix="6301" com-building-code="RHOB" com-phone="225-6371">
+            <committee-fullname>Committee on Science, Space, and Technology</committee-fullname>
+            <ratio>
+                <majority>22</majority>
+                <minority>17</minority>
+            </ratio>
+            <subcommittee subcomcode="SY15" subcom-room="4220" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="225-6371">
+                <subcommittee-fullname>Research and Technology</subcommittee-fullname>
+                <ratio>
+                    <majority>9</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="SY16" subcom-room="4220" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="OFOB" subcom-phone="225-6371">
+                <subcommittee-fullname>Space</subcommittee-fullname>
+                <ratio>
+                    <majority>14</majority>
+                    <minority>10</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="SY18" subcom-room="2319" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-6371">
+                <subcommittee-fullname>Environment</subcommittee-fullname>
+                <ratio>
+                    <majority>10</majority>
+                    <minority>7</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="SY20" subcom-room="2319" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-6371">
+                <subcommittee-fullname>Energy</subcommittee-fullname>
+                <ratio>
+                    <majority>11</majority>
+                    <minority>8</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="SY21" subcom-room="2321" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-6371">
+                <subcommittee-fullname>Oversight</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="VR00" com-room="335" com-zip="20515" com-zip-suffix="6335" com-building-code="CHOB" com-phone="225-3527">
+            <committee-fullname>Committee on Veterans' Affairs</committee-fullname>
+            <ratio>
+                <majority>14</majority>
+                <minority>10</minority>
+            </ratio>
+            <subcommittee subcomcode="VR03" subcom-room="338" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="CHOB" subcom-phone="225-9154">
+                <subcommittee-fullname>Health</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>5</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="VR08" subcom-room="337A" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="CHOB" subcom-phone="225-3569">
+                <subcommittee-fullname>Oversight and Investigations</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="VR09" subcom-room="337" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="CHOB" subcom-phone="225-9164">
+                <subcommittee-fullname>Disability Assistance and Memorial Affairs</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>3</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="VR10" subcom-room="335" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="CHOB" subcom-phone="226-5491">
+                <subcommittee-fullname>Economic Opportunity</subcommittee-fullname>
+                <ratio>
+                    <majority>5</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="standing" comcode="WM00" com-room="1102" com-zip="20515" com-zip-suffix="6348" com-building-code="LHOB" com-phone="225-3625">
+            <committee-fullname>Committee on Ways and Means</committee-fullname>
+            <ratio>
+                <majority>24</majority>
+                <minority>16</minority>
+            </ratio>
+            <subcommittee subcomcode="WM01" subcom-room="2018" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-9263">
+                <subcommittee-fullname>Social Security</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="WM02" subcom-room="1104" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-3943">
+                <subcommittee-fullname>Health</subcommittee-fullname>
+                <ratio>
+                    <majority>11</majority>
+                    <minority>7</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="WM03" subcom-room="1129" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-1025">
+                <subcommittee-fullname>Human Resources</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="WM04" subcom-room="1103" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-6649">
+                <subcommittee-fullname>Trade</subcommittee-fullname>
+                <ratio>
+                    <majority>10</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="WM05" subcom-room="1136" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="LHOB" subcom-phone="225-5522">
+                <subcommittee-fullname>Tax Policy</subcommittee-fullname>
+                <ratio>
+                    <majority>9</majority>
+                    <minority>6</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="WM06" subcom-room="2018" subcom-zip="20515" subcom-zip-suffix="0" subcom-building-code="RHOB" subcom-phone="225-9263">
+                <subcommittee-fullname>Oversight</subcommittee-fullname>
+                <ratio>
+                    <majority>7</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="select" comcode="IG00" com-room="HVC304" com-header-text="" com-zip="20515" com-zip-suffix="6415" com-building-code="C" com-phone="225-4121">
+            <committee-fullname>Permanent Select Committee on Intelligence</committee-fullname>
+            <ratio>
+                <majority>13</majority>
+                <minority>9</minority>
+            </ratio>
+            <subcommittee subcomcode="IG01" subcom-room="HVC304" subcom-zip="20515" subcom-zip-suffix="6415" subcom-building-code="C" subcom-phone="225-4121">
+                <subcommittee-fullname>Central Intelligence Agency</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="IG02" subcom-room="HVC304" subcom-zip="20515" subcom-zip-suffix="6415" subcom-building-code="C" subcom-phone="225-4121">
+                <subcommittee-fullname>National Security Agency and Cybersecurity</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="IG03" subcom-room="HVC304" subcom-zip="20515" subcom-zip-suffix="6415" subcom-building-code="C" subcom-phone="225-4121">
+                <subcommittee-fullname>Emerging Threats</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+            <subcommittee subcomcode="IG04" subcom-room="HVC304" subcom-zip="20515" subcom-zip-suffix="6415" subcom-building-code="C" subcom-phone="225-4121">
+                <subcommittee-fullname>Department of Defense Intelligence and Overhead Architecture</subcommittee-fullname>
+                <ratio>
+                    <majority>6</majority>
+                    <minority>4</minority>
+                </ratio>
+            </subcommittee>
+        </committee>
+        <committee type="joint" comcode="EC00" com-room="SD-G01" com-header-text="" com-zip="20510" com-zip-suffix="6432" com-building-code="DSOB" com-phone="224-5171">
+            <committee-fullname>Joint Economic Committee</committee-fullname>
+            <ratio>
+                <majority>0</majority>
+                <minority>0</minority>
+            </ratio>
+        </committee>
+        <committee type="joint" comcode="IT00" com-room="502" com-header-text="" com-zip="20515" com-zip-suffix="6453" com-building-code="FHOB" com-phone="225-3621">
+            <committee-fullname>Joint Committee on Taxation</committee-fullname>
+            <ratio>
+                <majority>0</majority>
+                <minority>0</minority>
+            </ratio>
+        </committee>
+        <committee type="joint" comcode="JL00" com-room="1309" com-header-text="" com-zip="20515" com-zip-suffix="6157" com-building-code="LHOB" com-phone="225-8281">
+            <committee-fullname>Joint Committee on the Library</committee-fullname>
+            <ratio>
+                <majority>0</majority>
+                <minority>0</minority>
+            </ratio>
+        </committee>
+        <committee type="joint" comcode="JP00" com-room="SR-305" com-header-text="" com-zip="20515" com-zip-suffix="6446" com-building-code="RSOB" com-phone="224-6352">
+            <committee-fullname>Joint Committee on Printing</committee-fullname>
+            <ratio>
+                <majority>6</majority>
+                <minority>4</minority>
+            </ratio>
+        </committee>
+    </committees>
+</MemberData>`
+};

--- a/backend/tests/fixtures/senate.js
+++ b/backend/tests/fixtures/senate.js
@@ -1,0 +1,1215 @@
+/* jshint node: true */
+
+module.exports = {
+  SENATORS: `<?xml version="1.0" encoding="UTF-8"?><contact_information><member>
+        <member_full>Alexander (R-TN)</member_full>
+        <last_name>Alexander</last_name>
+        <first_name>Lamar</first_name>
+        <party>R</party>
+        <state>TN</state>
+        <address>455 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4944</phone>
+        <email>http://www.alexander.senate.gov/public/index.cfm?p=Email</email>
+        <website>http://www.alexander.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>A000360</bioguide_id>
+    </member><member>
+        <member_full>Baldwin (D-WI)</member_full>
+        <last_name>Baldwin</last_name>
+        <first_name>Tammy</first_name>
+        <party>D</party>
+        <state>WI</state>
+        <address>709 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5653</phone>
+        <email>https://www.baldwin.senate.gov/feedback</email>
+        <website>http://www.baldwin.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>B001230</bioguide_id>
+    </member><member>
+        <member_full>Barrasso (R-WY)</member_full>
+        <last_name>Barrasso</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>WY</state>
+        <address>307 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6441</phone>
+        <email>https://www.barrasso.senate.gov/public/index.cfm/contact-form</email>
+        <website>http://www.barrasso.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>B001261</bioguide_id>
+    </member><member>
+        <member_full>Bennet (D-CO)</member_full>
+        <last_name>Bennet</last_name>
+        <first_name>Michael F.</first_name>
+        <party>D</party>
+        <state>CO</state>
+        <address>261 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5852</phone>
+        <email>https://www.bennet.senate.gov/?p=contact</email>
+        <website>http://www.bennet.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>B001267</bioguide_id>
+    </member><member>
+        <member_full>Blumenthal (D-CT)</member_full>
+        <last_name>Blumenthal</last_name>
+        <first_name>Richard</first_name>
+        <party>D</party>
+        <state>CT</state>
+        <address>706 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2823</phone>
+        <email>https://www.blumenthal.senate.gov/contact/</email>
+        <website>http://www.blumenthal.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>B001277</bioguide_id>
+    </member><member>
+        <member_full>Blunt (R-MO)</member_full>
+        <last_name>Blunt</last_name>
+        <first_name>Roy</first_name>
+        <party>R</party>
+        <state>MO</state>
+        <address>260 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5721</phone>
+        <email>https://www.blunt.senate.gov/public/index.cfm/contact-roy</email>
+        <website>http://www.blunt.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>B000575</bioguide_id>
+    </member><member>
+        <member_full>Booker (D-NJ)</member_full>
+        <last_name>Booker</last_name>
+        <first_name>Cory A.</first_name>
+        <party>D</party>
+        <state>NJ</state>
+        <address>359 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3224</phone>
+        <email>https://www.booker.senate.gov/?p=contact</email>
+        <website>http://www.booker.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>B001288</bioguide_id>
+    </member><member>
+        <member_full>Boozman (R-AR)</member_full>
+        <last_name>Boozman</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>AR</state>
+        <address>141 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4843</phone>
+        <email>https://www.boozman.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.boozman.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>B001236</bioguide_id>
+    </member><member>
+        <member_full>Brown (D-OH)</member_full>
+        <last_name>Brown</last_name>
+        <first_name>Sherrod</first_name>
+        <party>D</party>
+        <state>OH</state>
+        <address>713 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2315</phone>
+        <email>http://www.brown.senate.gov/contact/</email>
+        <website>http://www.brown.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>B000944</bioguide_id>
+    </member><member>
+        <member_full>Burr (R-NC)</member_full>
+        <last_name>Burr</last_name>
+        <first_name>Richard</first_name>
+        <party>R</party>
+        <state>NC</state>
+        <address>217 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3154</phone>
+        <email>https://www.burr.senate.gov/contact/email</email>
+        <website>http://www.burr.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>B001135</bioguide_id>
+    </member><member>
+        <member_full>Cantwell (D-WA)</member_full>
+        <last_name>Cantwell</last_name>
+        <first_name>Maria</first_name>
+        <party>D</party>
+        <state>WA</state>
+        <address>511 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3441</phone>
+        <email>http://www.cantwell.senate.gov/public/index.cfm/email-maria</email>
+        <website>http://www.cantwell.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>C000127</bioguide_id>
+    </member><member>
+        <member_full>Capito (R-WV)</member_full>
+        <last_name>Capito</last_name>
+        <first_name>Shelley Moore</first_name>
+        <party>R</party>
+        <state>WV</state>
+        <address>172 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6472</phone>
+        <email>https://www.capito.senate.gov/contact/contact-shelley</email>
+        <website>http://www.capito.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C001047</bioguide_id>
+    </member><member>
+        <member_full>Cardin (D-MD)</member_full>
+        <last_name>Cardin</last_name>
+        <first_name>Benjamin L.</first_name>
+        <party>D</party>
+        <state>MD</state>
+        <address>509 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4524</phone>
+        <email>http://www.cardin.senate.gov/contact/</email>
+        <website>http://www.cardin.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>C000141</bioguide_id>
+    </member><member>
+        <member_full>Carper (D-DE)</member_full>
+        <last_name>Carper</last_name>
+        <first_name>Thomas R.</first_name>
+        <party>D</party>
+        <state>DE</state>
+        <address>513 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2441</phone>
+        <email>http://www.carper.senate.gov/public/index.cfm/email-senator-carper</email>
+        <website>http://www.carper.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>C000174</bioguide_id>
+    </member><member>
+        <member_full>Casey (D-PA)</member_full>
+        <last_name>Casey</last_name>
+        <first_name>Robert P., Jr.</first_name>
+        <party>D</party>
+        <state>PA</state>
+        <address>393 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6324</phone>
+        <email>https://www.casey.senate.gov/contact/</email>
+        <website>http://www.casey.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>C001070</bioguide_id>
+    </member><member>
+        <member_full>Cassidy (R-LA)</member_full>
+        <last_name>Cassidy</last_name>
+        <first_name>Bill</first_name>
+        <party>R</party>
+        <state>LA</state>
+        <address>520 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5824</phone>
+        <email>https://www.cassidy.senate.gov/contact</email>
+        <website>http://www.cassidy.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C001075</bioguide_id>
+    </member><member>
+        <member_full>Cochran (R-MS)</member_full>
+        <last_name>Cochran</last_name>
+        <first_name>Thad</first_name>
+        <party>R</party>
+        <state>MS</state>
+        <address>113 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5054</phone>
+        <email>https://www.cochran.senate.gov/public/index.cfm/email-me</email>
+        <website>http://www.cochran.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C000567</bioguide_id>
+    </member><member>
+        <member_full>Collins (R-ME)</member_full>
+        <last_name>Collins</last_name>
+        <first_name>Susan M.</first_name>
+        <party>R</party>
+        <state>ME</state>
+        <address>413 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2523</phone>
+        <email>http://www.collins.senate.gov/contact</email>
+        <website>http://www.collins.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C001035</bioguide_id>
+    </member><member>
+        <member_full>Coons (D-DE)</member_full>
+        <last_name>Coons</last_name>
+        <first_name>Christopher A.</first_name>
+        <party>D</party>
+        <state>DE</state>
+        <address>127A Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5042</phone>
+        <email>https://www.coons.senate.gov/contact</email>
+        <website>http://www.coons.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>C001088</bioguide_id>
+    </member><member>
+        <member_full>Corker (R-TN)</member_full>
+        <last_name>Corker</last_name>
+        <first_name>Bob</first_name>
+        <party>R</party>
+        <state>TN</state>
+        <address>425 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3344</phone>
+        <email>https://www.corker.senate.gov/public/index.cfm/emailme</email>
+        <website>http://www.corker.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>C001071</bioguide_id>
+    </member><member>
+        <member_full>Cornyn (R-TX)</member_full>
+        <last_name>Cornyn</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>TX</state>
+        <address>517 Hart Senate Office Building Washington DC 20510
+        </address>
+        <phone>(202) 224-2934</phone>
+        <email>https://www.cornyn.senate.gov/contact</email>
+        <website>http://www.cornyn.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>C001056</bioguide_id>
+        <leadership_position>Assistant Majority Leader</leadership_position>
+      </member><member>
+        <member_full>Cortez Masto (D-NV)</member_full>
+        <last_name>Cortez Masto</last_name>
+        <first_name>Catherine</first_name>
+        <party>D</party>
+        <state>NV</state>
+        <address>204 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3542</phone>
+        <email>https://www.cortezmasto.senate.gov/content/contact-senator</email>
+        <website>http://www.cortezmasto.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>C001113</bioguide_id>
+    </member><member>
+        <member_full>Cotton (R-AR)</member_full>
+        <last_name>Cotton</last_name>
+        <first_name>Tom</first_name>
+        <party>R</party>
+        <state>AR</state>
+        <address>124 Russell Senate Office Building Washington DC 20510
+        </address>
+        <phone>(202) 224-2353</phone>
+        <email>http://www.cotton.senate.gov/?p=contact</email>
+        <website>http://www.cotton.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>C001095</bioguide_id>
+    </member><member>
+        <member_full>Crapo (R-ID)</member_full>
+        <last_name>Crapo</last_name>
+        <first_name>Mike</first_name>
+        <party>R</party>
+        <state>ID</state>
+        <address>239 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6142</phone>
+        <email>https://www.crapo.senate.gov/contact</email>
+        <website>http://www.crapo.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>C000880</bioguide_id>
+    </member><member>
+        <member_full>Cruz (R-TX)</member_full>
+        <last_name>Cruz</last_name>
+        <first_name>Ted</first_name>
+        <party>R</party>
+        <state>TX</state>
+        <address>404 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5922</phone>
+        <email>http://www.cruz.senate.gov/?p=email_senator</email>
+        <website>http://www.cruz.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>C001098</bioguide_id>
+    </member><member>
+        <member_full>Daines (R-MT)</member_full>
+        <last_name>Daines</last_name>
+        <first_name>Steve</first_name>
+        <party>R</party>
+        <state>MT</state>
+        <address>320 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2651</phone>
+        <email>https://www.daines.senate.gov/connect/email-steve</email>
+        <website>http://www.daines.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>D000618</bioguide_id>
+    </member><member>
+        <member_full>Donnelly (D-IN)</member_full>
+        <last_name>Donnelly</last_name>
+        <first_name>Joe</first_name>
+        <party>D</party>
+        <state>IN</state>
+        <address>720 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4814</phone>
+        <email>https://www.donnelly.senate.gov/contact/email-joe</email>
+        <website>http://www.donnelly.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>D000607</bioguide_id>
+    </member><member>
+        <member_full>Duckworth (D-IL)</member_full>
+        <last_name>Duckworth</last_name>
+        <first_name>Tammy</first_name>
+        <party>D</party>
+        <state>IL</state>
+        <address>524 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2854</phone>
+        <email>https://www.duckworth.senate.gov/content/contact-senator</email>
+        <website>http://www.duckworth.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>D000622</bioguide_id>
+    </member><member>
+        <member_full>Durbin (D-IL)</member_full>
+        <last_name>Durbin</last_name>
+        <first_name>Richard J.</first_name>
+        <party>D</party>
+        <state>IL</state>
+        <address>711 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2152</phone>
+        <email>https://www.durbin.senate.gov/contact/</email>
+        <website>http://www.durbin.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>D000563</bioguide_id>
+        <leadership_position>Whip</leadership_position>
+    </member><member>
+        <member_full>Enzi (R-WY)</member_full>
+        <last_name>Enzi</last_name>
+        <first_name>Michael B.</first_name>
+        <party>R</party>
+        <state>WY</state>
+        <address>379A Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3424</phone>
+        <email>http://www.enzi.senate.gov/public/index.cfm/contact?p=e-mail-senator-enzi</email>
+        <website>http://www.enzi.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>E000285</bioguide_id>
+    </member><member>
+        <member_full>Ernst (R-IA)</member_full>
+        <last_name>Ernst</last_name>
+        <first_name>Joni</first_name>
+        <party>R</party>
+        <state>IA</state>
+        <address>111 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3254</phone>
+        <email>https://www.ernst.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.ernst.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>E000295</bioguide_id>
+    </member><member>
+        <member_full>Feinstein (D-CA)</member_full>
+        <last_name>Feinstein</last_name>
+        <first_name>Dianne</first_name>
+        <party>D</party>
+        <state>CA</state>
+        <address>331 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3841</phone>
+        <email>https://www.feinstein.senate.gov/public/index.cfm/e-mail-me</email>
+        <website>http://www.feinstein.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>F000062</bioguide_id>
+    </member><member>
+        <member_full>Fischer (R-NE)</member_full>
+        <last_name>Fischer</last_name>
+        <first_name>Deb</first_name>
+        <party>R</party>
+        <state>NE</state>
+        <address>454 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6551</phone>
+        <email>http://www.fischer.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.fischer.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>F000463</bioguide_id>
+    </member><member>
+        <member_full>Flake (R-AZ)</member_full>
+        <last_name>Flake</last_name>
+        <first_name>Jeff</first_name>
+        <party>R</party>
+        <state>AZ</state>
+        <address>413 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4521</phone>
+        <email>https://www.flake.senate.gov/public/index.cfm/contact-jeff</email>
+        <website>http://www.flake.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>F000444</bioguide_id>
+    </member><member>
+        <member_full>Franken (D-MN)</member_full>
+        <last_name>Franken</last_name>
+        <first_name>Al</first_name>
+        <party>D</party>
+        <state>MN</state>
+        <address>309 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5641</phone>
+        <email>https://www.franken.senate.gov/?p=contact</email>
+        <website>http://www.franken.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>F000457</bioguide_id>
+    </member><member>
+        <member_full>Gardner (R-CO)</member_full>
+        <last_name>Gardner</last_name>
+        <first_name>Cory</first_name>
+        <party>R</party>
+        <state>CO</state>
+        <address>354 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5941</phone>
+        <email>https://www.gardner.senate.gov/contact-cory/email-cory</email>
+        <website>http://www.gardner.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>G000562</bioguide_id>
+    </member><member>
+        <member_full>Gillibrand (D-NY)</member_full>
+        <last_name>Gillibrand</last_name>
+        <first_name>Kirsten E.</first_name>
+        <party>D</party>
+        <state>NY</state>
+        <address>478 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4451</phone>
+        <email>http://www.gillibrand.senate.gov/contact/</email>
+        <website>http://www.gillibrand.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>G000555</bioguide_id>
+    </member><member>
+        <member_full>Graham (R-SC)</member_full>
+        <last_name>Graham</last_name>
+        <first_name>Lindsey</first_name>
+        <party>R</party>
+        <state>SC</state>
+        <address>290 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5972</phone>
+        <email>https://www.lgraham.senate.gov/public/index.cfm/e-mail-senator-graham</email>
+        <website>http://www.lgraham.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>G000359</bioguide_id>
+    </member><member>
+        <member_full>Grassley (R-IA)</member_full>
+        <last_name>Grassley</last_name>
+        <first_name>Chuck</first_name>
+        <party>R</party>
+        <state>IA</state>
+        <address>135 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3744</phone>
+        <email>http://www.grassley.senate.gov/contact</email>
+        <website>http://www.grassley.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>G000386</bioguide_id>
+    </member><member>
+        <member_full>Harris (D-CA)</member_full>
+        <last_name>Harris</last_name>
+        <first_name>Kamala D.</first_name>
+        <party>D</party>
+        <state>CA</state>
+        <address>112 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3553</phone>
+        <email>https://www.harris.senate.gov/content/contact-senator</email>
+        <website>http://www.harris.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>H001075</bioguide_id>
+    </member><member>
+        <member_full>Hassan (D-NH)</member_full>
+        <last_name>Hassan</last_name>
+        <first_name>Margaret Wood</first_name>
+        <party>D</party>
+        <state>NH</state>
+        <address>330 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3324</phone>
+        <email>https://www.hassan.senate.gov/content/contact-senator</email>
+        <website>http://www.hassan.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>H001076</bioguide_id>
+    </member><member>
+        <member_full>Hatch (R-UT)</member_full>
+        <last_name>Hatch</last_name>
+        <first_name>Orrin G.</first_name>
+        <party>R</party>
+        <state>UT</state>
+        <address>104 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5251</phone>
+        <email>http://www.hatch.senate.gov/public/index.cfm/contact?p=Email-Orrin</email>
+        <website>http://www.hatch.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>H000338</bioguide_id>
+        <leadership_position>President Pro Tempore</leadership_position>
+    </member><member>
+        <member_full>Heinrich (D-NM)</member_full>
+        <last_name>Heinrich</last_name>
+        <first_name>Martin</first_name>
+        <party>D</party>
+        <state>NM</state>
+        <address>303 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5521</phone>
+        <email>http://www.heinrich.senate.gov/contact</email>
+        <website>http://www.heinrich.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>H001046</bioguide_id>
+    </member><member>
+        <member_full>Heitkamp (D-ND)</member_full>
+        <last_name>Heitkamp</last_name>
+        <first_name>Heidi</first_name>
+        <party>D</party>
+        <state>ND</state>
+        <address>516 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2043</phone>
+        <email>http://www.heitkamp.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.heitkamp.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>H001069</bioguide_id>
+    </member><member>
+        <member_full>Heller (R-NV)</member_full>
+        <last_name>Heller</last_name>
+        <first_name>Dean</first_name>
+        <party>R</party>
+        <state>NV</state>
+        <address>324 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6244</phone>
+        <email>http://www.heller.senate.gov/public/index.cfm/contact-form</email>
+        <website>http://www.heller.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>H001041</bioguide_id>
+    </member><member>
+        <member_full>Hirono (D-HI)</member_full>
+        <last_name>Hirono</last_name>
+        <first_name>Mazie K.</first_name>
+        <party>D</party>
+        <state>HI</state>
+        <address>730 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6361</phone>
+        <email>https://www.hirono.senate.gov/contact</email>
+        <website>http://www.hirono.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>H001042</bioguide_id>
+    </member><member>
+        <member_full>Hoeven (R-ND)</member_full>
+        <last_name>Hoeven</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>ND</state>
+        <address>338 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2551</phone>
+        <email>http://www.hoeven.senate.gov/public/index.cfm/email-the-senator</email>
+        <website>http://www.hoeven.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>H001061</bioguide_id>
+    </member><member>
+        <member_full>Inhofe (R-OK)</member_full>
+        <last_name>Inhofe</last_name>
+        <first_name>James M.</first_name>
+        <party>R</party>
+        <state>OK</state>
+        <address>205 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4721</phone>
+        <email>https://www.inhofe.senate.gov/contact</email>
+        <website>http://www.inhofe.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>I000024</bioguide_id>
+    </member><member>
+        <member_full>Isakson (R-GA)</member_full>
+        <last_name>Isakson</last_name>
+        <first_name>Johnny</first_name>
+        <party>R</party>
+        <state>GA</state>
+        <address>131 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3643</phone>
+        <email>https://www.isakson.senate.gov/public/index.cfm/email-me</email>
+        <website>http://www.isakson.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>I000055</bioguide_id>
+    </member><member>
+        <member_full>Johnson (R-WI)</member_full>
+        <last_name>Johnson</last_name>
+        <first_name>Ron</first_name>
+        <party>R</party>
+        <state>WI</state>
+        <address>328 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5323</phone>
+        <email>https://www.ronjohnson.senate.gov/public/index.cfm/email-the-senator</email>
+        <website>http://www.ronjohnson.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>J000293</bioguide_id>
+    </member><member>
+        <member_full>Kaine (D-VA)</member_full>
+        <last_name>Kaine</last_name>
+        <first_name>Tim</first_name>
+        <party>D</party>
+        <state>VA</state>
+        <address>231 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4024</phone>
+        <email>https://www.kaine.senate.gov/contact</email>
+        <website>http://www.kaine.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>K000384</bioguide_id>
+    </member><member>
+        <member_full>Kennedy (R-LA)</member_full>
+        <last_name>Kennedy</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>LA</state>
+        <address>383 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4623</phone>
+        <email>https://www.kennedy.senate.gov/content/contact-senator</email>
+        <website>http://www.kennedy.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>K000393</bioguide_id>
+    </member><member>
+        <member_full>King (I-ME)</member_full>
+        <last_name>King</last_name>
+        <first_name>Angus S., Jr.</first_name>
+        <party>I</party>
+        <state>ME</state>
+        <address>133 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5344</phone>
+        <email>https://www.king.senate.gov/contact</email>
+        <website>http://www.king.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>K000383</bioguide_id>
+    </member><member>
+        <member_full>Klobuchar (D-MN)</member_full>
+        <last_name>Klobuchar</last_name>
+        <first_name>Amy</first_name>
+        <party>D</party>
+        <state>MN</state>
+        <address>302 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3244</phone>
+        <email>http://www.klobuchar.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.klobuchar.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>K000367</bioguide_id>
+    </member><member>
+        <member_full>Lankford (R-OK)</member_full>
+        <last_name>Lankford</last_name>
+        <first_name>James</first_name>
+        <party>R</party>
+        <state>OK</state>
+        <address>316 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5754</phone>
+        <email>http://www.lankford.senate.gov/contact/email</email>
+        <website>http://www.lankford.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>L000575</bioguide_id>
+    </member><member>
+        <member_full>Leahy (D-VT)</member_full>
+        <last_name>Leahy</last_name>
+        <first_name>Patrick J.</first_name>
+        <party>D</party>
+        <state>VT</state>
+        <address>437 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4242</phone>
+        <email>https://www.leahy.senate.gov/contact/</email>
+        <website>http://www.leahy.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>L000174</bioguide_id>
+    </member><member>
+        <member_full>Lee (R-UT)</member_full>
+        <last_name>Lee</last_name>
+        <first_name>Mike</first_name>
+        <party>R</party>
+        <state>UT</state>
+        <address>361A Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5444</phone>
+        <email>https://www.lee.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.lee.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>L000577</bioguide_id>
+    </member><member>
+        <member_full>Manchin (D-WV)</member_full>
+        <last_name>Manchin</last_name>
+        <first_name>Joe, III</first_name>
+        <party>D</party>
+        <state>WV</state>
+        <address>306 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3954</phone>
+        <email>http://www.manchin.senate.gov/public/index.cfm/contact-form</email>
+        <website>http://www.manchin.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>M001183</bioguide_id>
+    </member><member>
+        <member_full>Markey (D-MA)</member_full>
+        <last_name>Markey</last_name>
+        <first_name>Edward J.</first_name>
+        <party>D</party>
+        <state>MA</state>
+        <address>255 Dirksen Senate Office Building Washington DC 20510
+        </address>
+        <phone>(202) 224-2742</phone>
+        <email>https://www.markey.senate.gov/contact</email>
+        <website>http://www.markey.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>M000133</bioguide_id>
+    </member><member>
+        <member_full>McCain (R-AZ)</member_full>
+        <last_name>McCain</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>AZ</state>
+        <address>218 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2235</phone>
+        <email>https://www.mccain.senate.gov/public/index.cfm/contact-form</email>
+        <website>http://www.mccain.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>M000303</bioguide_id>
+    </member><member>
+        <member_full>McCaskill (D-MO)</member_full>
+        <last_name>McCaskill</last_name>
+        <first_name>Claire</first_name>
+        <party>D</party>
+        <state>MO</state>
+        <address>503 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6154</phone>
+        <email>http://www.mccaskill.senate.gov/contact</email>
+        <website>http://www.mccaskill.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>M001170</bioguide_id>
+    </member><member>
+        <member_full>McConnell (R-KY)</member_full>
+        <last_name>McConnell</last_name>
+        <first_name>Mitch</first_name>
+        <party>R</party>
+        <state>KY</state>
+        <address>317 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2541</phone>
+        <email>http://www.mcconnell.senate.gov/public/index.cfm?p=contact</email>
+        <website>http://www.mcconnell.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>M000355</bioguide_id>
+        <leadership_position>Majority Leader</leadership_position>
+    </member><member>
+        <member_full>Menendez (D-NJ)</member_full>
+        <last_name>Menendez</last_name>
+        <first_name>Robert</first_name>
+        <party>D</party>
+        <state>NJ</state>
+        <address>528 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4744</phone>
+        <email>https://www.menendez.senate.gov/contact</email>
+        <website>http://www.menendez.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>M000639</bioguide_id>
+    </member><member>
+        <member_full>Merkley (D-OR)</member_full>
+        <last_name>Merkley</last_name>
+        <first_name>Jeff</first_name>
+        <party>D</party>
+        <state>OR</state>
+        <address>313 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3753</phone>
+        <email>http://www.merkley.senate.gov/contact/</email>
+        <website>http://www.merkley.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>M001176</bioguide_id>
+    </member><member>
+        <member_full>Moran (R-KS)</member_full>
+        <last_name>Moran</last_name>
+        <first_name>Jerry</first_name>
+        <party>R</party>
+        <state>KS</state>
+        <address>521 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6521</phone>
+        <email>https://www.moran.senate.gov/public/index.cfm/e-mail-jerry</email>
+        <website>http://www.moran.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>M000934</bioguide_id>
+    </member><member>
+        <member_full>Murkowski (R-AK)</member_full>
+        <last_name>Murkowski</last_name>
+        <first_name>Lisa</first_name>
+        <party>R</party>
+        <state>AK</state>
+        <address>522 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6665</phone>
+        <email>https://www.murkowski.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.murkowski.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>M001153</bioguide_id>
+    </member><member>
+        <member_full>Murphy (D-CT)</member_full>
+        <last_name>Murphy</last_name>
+        <first_name>Christopher</first_name>
+        <party>D</party>
+        <state>CT</state>
+        <address>136 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4041</phone>
+        <email>http://www.murphy.senate.gov/contact</email>
+        <website>http://www.murphy.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>M001169</bioguide_id>
+    </member><member>
+        <member_full>Murray (D-WA)</member_full>
+        <last_name>Murray</last_name>
+        <first_name>Patty</first_name>
+        <party>D</party>
+        <state>WA</state>
+        <address>154 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2621</phone>
+        <email>http://www.murray.senate.gov/public/index.cfm/contactme</email>
+        <website>http://www.murray.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>M001111</bioguide_id>
+        <leadership_position>Assistant Democratic Leader</leadership_position>
+    </member><member>
+        <member_full>Nelson (D-FL)</member_full>
+        <last_name>Nelson</last_name>
+        <first_name>Bill</first_name>
+        <party>D</party>
+        <state>FL</state>
+        <address>716 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5274</phone>
+        <email>https://www.billnelson.senate.gov/contact-bill</email>
+        <website>http://www.billnelson.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>N000032</bioguide_id>
+    </member><member>
+        <member_full>Paul (R-KY)</member_full>
+        <last_name>Paul</last_name>
+        <first_name>Rand</first_name>
+        <party>R</party>
+        <state>KY</state>
+        <address>167 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4343</phone>
+        <email>https://www.paul.senate.gov/connect/email-rand</email>
+        <website>http://www.paul.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>P000603</bioguide_id>
+    </member><member>
+        <member_full>Perdue (R-GA)</member_full>
+        <last_name>Perdue</last_name>
+        <first_name>David</first_name>
+        <party>R</party>
+        <state>GA</state>
+        <address>455 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3521</phone>
+        <email>https://www.perdue.senate.gov/connect/email</email>
+        <website>http://www.perdue.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>P000612</bioguide_id>
+    </member><member>
+        <member_full>Peters (D-MI)</member_full>
+        <last_name>Peters</last_name>
+        <first_name>Gary C.</first_name>
+        <party>D</party>
+        <state>MI</state>
+        <address>724 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6221</phone>
+        <email>https://www.peters.senate.gov/contact/email-gary</email>
+        <website>http://www.peters.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>P000595</bioguide_id>
+    </member><member>
+        <member_full>Portman (R-OH)</member_full>
+        <last_name>Portman</last_name>
+        <first_name>Rob</first_name>
+        <party>R</party>
+        <state>OH</state>
+        <address>448 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3353</phone>
+        <email>https://www.portman.senate.gov/public/index.cfm/contact?p=contact-form</email>
+        <website>http://www.portman.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>P000449</bioguide_id>
+    </member><member>
+        <member_full>Reed (D-RI)</member_full>
+        <last_name>Reed</last_name>
+        <first_name>Jack</first_name>
+        <party>D</party>
+        <state>RI</state>
+        <address>728 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4642</phone>
+        <email>https://www.reed.senate.gov/contact/</email>
+        <website>http://www.reed.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>R000122</bioguide_id>
+    </member><member>
+        <member_full>Risch (R-ID)</member_full>
+        <last_name>Risch</last_name>
+        <first_name>James E.</first_name>
+        <party>R</party>
+        <state>ID</state>
+        <address>483 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2752</phone>
+        <email>http://www.risch.senate.gov/public/index.cfm?p=Email</email>
+        <website>http://www.risch.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>R000584</bioguide_id>
+    </member><member>
+        <member_full>Roberts (R-KS)</member_full>
+        <last_name>Roberts</last_name>
+        <first_name>Pat</first_name>
+        <party>R</party>
+        <state>KS</state>
+        <address>109 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4774</phone>
+        <email>https://www.roberts.senate.gov/public/?p=EmailPat</email>
+        <website>http://www.roberts.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>R000307</bioguide_id>
+    </member><member>
+        <member_full>Rounds (R-SD)</member_full>
+        <last_name>Rounds</last_name>
+        <first_name>Mike</first_name>
+        <party>R</party>
+        <state>SD</state>
+        <address>502 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5842</phone>
+        <email>https://www.rounds.senate.gov/contact/email-mike</email>
+        <website>http://www.rounds.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>R000605</bioguide_id>
+    </member><member>
+        <member_full>Rubio (R-FL)</member_full>
+        <last_name>Rubio</last_name>
+        <first_name>Marco</first_name>
+        <party>R</party>
+        <state>FL</state>
+        <address>284 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3041</phone>
+        <email>http://www.rubio.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.rubio.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>R000595</bioguide_id>
+    </member><member>
+        <member_full>Sanders (I-VT)</member_full>
+        <last_name>Sanders</last_name>
+        <first_name>Bernard</first_name>
+        <party>I</party>
+        <state>VT</state>
+        <address>332 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5141</phone>
+        <email>http://www.sanders.senate.gov/contact/</email>
+        <website>http://www.sanders.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>S000033</bioguide_id>
+    </member><member>
+        <member_full>Sasse (R-NE)</member_full>
+        <last_name>Sasse</last_name>
+        <first_name>Ben</first_name>
+        <party>R</party>
+        <state>NE</state>
+        <address>136 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4224</phone>
+        <email>http://www.sasse.senate.gov/public/index.cfm/email-ben</email>
+        <website>http://www.sasse.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>S001197</bioguide_id>
+    </member><member>
+      <member_full>Schatz (D-HI)</member_full>
+      <last_name>Schatz</last_name>
+      <first_name>Brian</first_name>
+      <party>D</party>
+      <state>HI</state>
+      <address>722 Hart Senate Office Building Washington DC 20510</address>
+      <phone>(202) 224-3934</phone>
+      <email>https://www.schatz.senate.gov/contact</email>
+      <website>http://www.schatz.senate.gov</website>
+      <class>Class III</class>
+      <bioguide_id>S001194</bioguide_id>
+    </member><member>
+        <member_full>Schumer (D-NY)</member_full>
+        <last_name>Schumer</last_name>
+        <first_name>Charles E.</first_name>
+        <party>D</party>
+        <state>NY</state>
+        <address>322 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6542</phone>
+        <email>https://www.schumer.senate.gov/contact/email-chuck</email>
+        <website>http://www.schumer.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>S000148</bioguide_id>
+        <leadership_position>Democratic Leader</leadership_position>
+    </member><member>
+        <member_full>Scott (R-SC)</member_full>
+        <last_name>Scott</last_name>
+        <first_name>Tim</first_name>
+        <party>R</party>
+        <state>SC</state>
+        <address>717 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6121</phone>
+        <email>https://www.scott.senate.gov/contact/email-me</email>
+        <website>http://www.scott.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>S001184</bioguide_id>
+    </member><member>
+        <member_full>Shaheen (D-NH)</member_full>
+        <last_name>Shaheen</last_name>
+        <first_name>Jeanne</first_name>
+        <party>D</party>
+        <state>NH</state>
+        <address>506 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2841</phone>
+        <email>https://www.shaheen.senate.gov/contact/contact-jeanne</email>
+        <website>http://www.shaheen.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>S001181</bioguide_id>
+    </member><member>
+        <member_full>Shelby (R-AL)</member_full>
+        <last_name>Shelby</last_name>
+        <first_name>Richard C.</first_name>
+        <party>R</party>
+        <state>AL</state>
+        <address>304 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5744</phone>
+        <email>https://www.shelby.senate.gov/public/index.cfm/emailsenatorshelby</email>
+        <website>http://www.shelby.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>S000320</bioguide_id>
+    </member><member>
+        <member_full>Stabenow (D-MI)</member_full>
+        <last_name>Stabenow</last_name>
+        <first_name>Debbie</first_name>
+        <party>D</party>
+        <state>MI</state>
+        <address>731 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4822</phone>
+        <email>https://www.stabenow.senate.gov/contact</email>
+        <website>http://www.stabenow.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>S000770</bioguide_id>
+    </member><member>
+        <member_full>Strange (R-AL)</member_full>
+        <last_name>Strange</last_name>
+        <first_name>Luther</first_name>
+        <party>R</party>
+        <state>AL</state>
+        <address>326 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4124</phone>
+        <email>https://www.strange.senate.gov/content/contact-senator</email>
+        <website>https://www.strange.senate.gov/</website>
+        <class>Class II</class>
+        <bioguide_id>S001202</bioguide_id>
+    </member><member>
+        <member_full>Sullivan (R-AK)</member_full>
+        <last_name>Sullivan</last_name>
+        <first_name>Dan</first_name>
+        <party>R</party>
+        <state>AK</state>
+        <address>702 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-3004</phone>
+        <email>https://www.sullivan.senate.gov/contact/email</email>
+        <website>http://www.sullivan.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>S001198</bioguide_id>
+    </member><member>
+        <member_full>Tester (D-MT)</member_full>
+        <last_name>Tester</last_name>
+        <first_name>Jon</first_name>
+        <party>D</party>
+        <state>MT</state>
+        <address>311 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2644</phone>
+        <email>https://www.tester.senate.gov/?p=email_senator</email>
+        <website>http://www.tester.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>T000464</bioguide_id>
+    </member><member>
+        <member_full>Thune (R-SD)</member_full>
+        <last_name>Thune</last_name>
+        <first_name>John</first_name>
+        <party>R</party>
+        <state>SD</state>
+        <address>511 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2321</phone>
+        <email>http://www.thune.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.thune.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>T000250</bioguide_id>
+    </member><member>
+        <member_full>Tillis (R-NC)</member_full>
+        <last_name>Tillis</last_name>
+        <first_name>Thom</first_name>
+        <party>R</party>
+        <state>NC</state>
+        <address>185 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6342</phone>
+        <email>https://www.tillis.senate.gov/public/index.cfm/email-me</email>
+        <website>http://www.tillis.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>T000476</bioguide_id>
+    </member><member>
+        <member_full>Toomey (R-PA)</member_full>
+        <last_name>Toomey</last_name>
+        <first_name>Patrick J.</first_name>
+        <party>R</party>
+        <state>PA</state>
+        <address>248 Russell Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4254</phone>
+        <email>https://www.toomey.senate.gov/?p=contact</email>
+        <website>http://www.toomey.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>T000461</bioguide_id>
+    </member><member>
+        <member_full>Udall (D-NM)</member_full>
+        <last_name>Udall</last_name>
+        <first_name>Tom</first_name>
+        <party>D</party>
+        <state>NM</state>
+        <address>531 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6621</phone>
+        <email>https://www.tomudall.senate.gov/?p=contact</email>
+        <website>http://www.tomudall.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>U000039</bioguide_id>
+    </member><member>
+        <member_full>Van Hollen (D-MD)</member_full>
+        <last_name>Van Hollen</last_name>
+        <first_name>Chris</first_name>
+        <party>D</party>
+        <state>MD</state>
+        <address>110 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4654</phone>
+        <email>https://www.vanhollen.senate.gov/content/contact-senator</email>
+        <website>http://www.vanhollen.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>V000128</bioguide_id>
+    </member><member>
+        <member_full>Warner (D-VA)</member_full>
+        <last_name>Warner</last_name>
+        <first_name>Mark R.</first_name>
+        <party>D</party>
+        <state>VA</state>
+        <address>703 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2023</phone>
+        <email>http://www.warner.senate.gov/public/index.cfm?p=Contact</email>
+        <website>http://www.warner.senate.gov</website>
+        <class>Class II</class>
+        <bioguide_id>W000805</bioguide_id>
+    </member><member>
+        <member_full>Warren (D-MA)</member_full>
+        <last_name>Warren</last_name>
+        <first_name>Elizabeth</first_name>
+        <party>D</party>
+        <state>MA</state>
+        <address>317 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-4543</phone>
+        <email>https://www.warren.senate.gov/?p=email_senator</email>
+        <website>http://www.warren.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>W000817</bioguide_id>
+    </member><member>
+        <member_full>Whitehouse (D-RI)</member_full>
+        <last_name>Whitehouse</last_name>
+        <first_name>Sheldon</first_name>
+        <party>D</party>
+        <state>RI</state>
+        <address>530 Hart Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-2921</phone>
+        <email>https://www.whitehouse.senate.gov/contact/email-sheldon</email>
+        <website>http://www.whitehouse.senate.gov/</website>
+        <class>Class I</class>
+        <bioguide_id>W000802</bioguide_id>
+    </member><member>
+        <member_full>Wicker (R-MS)</member_full>
+        <last_name>Wicker</last_name>
+        <first_name>Roger F.</first_name>
+        <party>R</party>
+        <state>MS</state>
+        <address>555 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-6253</phone>
+        <email>https://www.wicker.senate.gov/public/index.cfm/contact</email>
+        <website>http://www.wicker.senate.gov</website>
+        <class>Class I</class>
+        <bioguide_id>W000437</bioguide_id>
+    </member><member>
+        <member_full>Wyden (D-OR)</member_full>
+        <last_name>Wyden</last_name>
+        <first_name>Ron</first_name>
+        <party>D</party>
+        <state>OR</state>
+        <address>221 Dirksen Senate Office Building Washington DC 20510</address>
+        <phone>(202) 224-5244</phone>
+        <email>https://www.wyden.senate.gov/contact/</email>
+        <website>http://www.wyden.senate.gov/</website>
+        <class>Class III</class>
+        <bioguide_id>W000779</bioguide_id>
+    </member><member>
+        <member_full>Young (R-IN)</member_full>
+        <last_name>Young</last_name>
+        <first_name>Todd</first_name>
+        <party>R</party>
+        <state>IN</state>
+        <address>400 Russell Senate Office Building Washington DC
+      20510</address>
+        <phone>(202) 224-5623</phone>
+        <email>https://www.young.senate.gov/content/contact-senator</email>
+        <website>http://www.young.senate.gov</website>
+        <class>Class III</class>
+        <bioguide_id>Y000064</bioguide_id>
+    </member><last_updated>Thursday, June 8, 2017: 9:35 AM EST</last_updated></contact_information>`
+};

--- a/package.json
+++ b/package.json
@@ -12,13 +12,10 @@
     "build": "ember build",
     "start": "node backend/app/server.js",
     "test": "npm run test:backend && npm run test:frontend",
-
     "backend": "PORT=3000 nodemon backend/app/server.js --ignore ./tmp/ --ignore ./app/",
     "frontend": "ember server --proxy http://127.0.0.1:3000",
-
     "test:backend": "mocha -R spec backend/tests/*-test.js",
     "test:frontend": "ember test",
-
     "test-server:backend": "mocha -R spec backend/tests/*-test.js -w",
     "test-server:frontend": "ember test --serve"
   },
@@ -57,6 +54,7 @@
   },
   "dependencies": {
     "express": "^4.14.0",
-    "request": "^2.79.0"
+    "request": "^2.79.0",
+    "xml-js": "^1.3.2"
   }
 }

--- a/tests/fixtures/congress.js
+++ b/tests/fixtures/congress.js
@@ -10,163 +10,32 @@ export const COMPLETE_CONGRESS = {
   },
   representatives: [
     {
-      caucus: null,
-      congress_numbers: [
-        114
-      ],
-      current: true,
-      description: "Representative for California's 12th congressional district",
-      district: 12,
-      enddate: "2017-01-03",
-      extra: {
-        address: "233 Cannon HOB; Washington DC 20515-0512",
-        contact_form: "http://pelosi.house.gov/contact-me/email-me",
-        fax: "202-225-8259",
-        office: "233 Cannon House Office Building",
-        rss_url: "http://pelosi.house.gov/atom.xml"
-      },
-      id: 43364,
-      leadership_title: "Minority Leader",
-      party: "Democrat",
       person: {
-        bioguideid: "P000197",
-        birthday: "1940-03-26",
-        cspanid: 6153,
-        firstname: "Nancy",
-        gender: "female",
-        gender_label: "Female",
-        id: 400314,
-        lastname: "Pelosi",
-        link: "https://www.govtrack.us/congress/members/nancy_pelosi/400314",
-        middlename: "",
-        name: "Rep. Nancy Pelosi [D-CA12]",
-        namemod: "",
-        nickname: "",
-        osid: "N00007360",
-        pvsid: "26732",
-        sortname: "Pelosi, Nancy (Rep.) [D-CA12]",
-        twitterid: "NancyPelosi",
-        youtubeid: "nancypelosi"
+        firstname: 'Nancy',
+        lastname: 'Pelosi'
       },
-      phone: "202-225-4965",
-      role_type: "representative",
-      role_type_label: "Representative",
-      senator_class: null,
-      senator_rank: null,
-      startdate: "2015-01-06",
-      state: "CA",
-      title: "Rep.",
-      title_long: "Representative",
-      website: "http://pelosi.house.gov"
+      title: 'Rep.',
+      party: 'Democrat',
+      phone: '(202) 225-4965'
     }
   ],
   senators: [
     {
-      caucus: null,
-      congress_numbers: [
-        112,
-        113,
-        114
-      ],
-      current: true,
-      description: "Junior Senator from California",
-      district: null,
-      enddate: "2017-01-03",
-      extra: {
-        address: "112 Hart Senate Office Building Washington DC 20510",
-        contact_form: "https://www.boxer.senate.gov/contact/shareyourviews.html",
-        fax: "202-224-0454",
-        office: "112 Hart Senate Office Building"
-      },
-      id: 3853,
-      leadership_title: null,
-      party: "Democrat",
       person: {
-        bioguideid: "B000711",
-        birthday: "1940-11-11",
-        cspanid: 2470,
-        firstname: "Barbara",
-        gender: "female",
-        gender_label: "Female",
-        id: 300011,
-        lastname: "Boxer",
-        link: "https://www.govtrack.us/congress/members/barbara_boxer/300011",
-        middlename: "",
-        name: "Sen. Barbara Boxer [D-CA]",
-        namemod: "",
-        nickname: "",
-        osid: "N00006692",
-        pvsid: "53274",
-        sortname: "Boxer, Barbara (Sen.) [D-CA]",
-        twitterid: "SenatorBoxer",
-        youtubeid: "SenatorBoxer"
+        firstname: 'Dianne',
+        lastname: 'Feinstein'
       },
-      phone: "202-224-3553",
-      role_type: "senator",
-      role_type_label: "Senator",
-      senator_class: "class3",
-      senator_class_label: "Class 3",
-      senator_rank: "junior",
-      senator_rank_label: "Junior",
-      startdate: "2011-01-05",
-      state: "CA",
-      title: "Sen.",
-      title_long: "Senator",
-      website: "https://www.boxer.senate.gov"
-    },
-    {
-      caucus: null,
-      congress_numbers: [
-        113,
-        114,
-        115
-      ],
-      current: true,
-      description: "Senior Senator from California",
-      district: null,
-      enddate: "2019-01-03",
-      extra: {
-        address: "331 Hart Senate Office Building Washington DC 20510",
-        contact_form: "https://www.feinstein.senate.gov/public/index.cfm/e-mail-me",
-        fax: "202-228-3954",
-        office: "331 Hart Senate Office Building",
-        rss_url: "http://www.feinstein.senate.gov/public/?a=rss.feed"
-      },
-      id: 42868,
-      leadership_title: null,
-      party: "Democrat",
+      title: 'Sen.',
+      party: 'Democrat',
+      phone: '(202) 224-3841'
+    }, {
       person: {
-        bioguideid: "F000062",
-        birthday: "1933-06-22",
-        cspanid: 13061,
-        firstname: "Dianne",
-        gender: "female",
-        gender_label: "Female",
-        id: 300043,
-        lastname: "Feinstein",
-        link: "https://www.govtrack.us/congress/members/dianne_feinstein/300043",
-        middlename: "",
-        name: "Sen. Dianne Feinstein [D-CA]",
-        namemod: "",
-        nickname: "",
-        osid: "N00007364",
-        pvsid: "53273",
-        sortname: "Feinstein, Dianne (Sen.) [D-CA]",
-        twitterid: "SenFeinstein",
-        youtubeid: "SenatorFeinstein"
+        firstname: 'Kamala D.',
+        lastname: 'Harris'
       },
-      phone: "202-224-3841",
-      role_type: "senator",
-      role_type_label: "Senator",
-      senator_class: "class1",
-      senator_class_label: "Class 1",
-      senator_rank: "senior",
-      senator_rank_label: "Senior",
-      startdate: "2013-01-03",
-      state: "CA",
-      title: "Sen.",
-      title_long: "Senator",
-      website: "http://www.feinstein.senate.gov"
+      title: 'Sen.',
+      party: 'Democrat',
+      phone: '(202) 224-3553'
     }
   ]
 };
@@ -174,163 +43,32 @@ export const COMPLETE_CONGRESS = {
 export const NO_DISTRICT = {
  representatives: [
     {
-      caucus: null,
-      congress_numbers: [
-        114
-      ],
-      current: true,
-      description: "Representative for California's 12th congressional district",
-      district: 12,
-      enddate: "2017-01-03",
-      extra: {
-        address: "233 Cannon HOB; Washington DC 20515-0512",
-        contact_form: "http://pelosi.house.gov/contact-me/email-me",
-        fax: "202-225-8259",
-        office: "233 Cannon House Office Building",
-        rss_url: "http://pelosi.house.gov/atom.xml"
-      },
-      id: 43364,
-      leadership_title: "Minority Leader",
-      party: "Democrat",
       person: {
-        bioguideid: "P000197",
-        birthday: "1940-03-26",
-        cspanid: 6153,
-        firstname: "Nancy",
-        gender: "female",
-        gender_label: "Female",
-        id: 400314,
-        lastname: "Pelosi",
-        link: "https://www.govtrack.us/congress/members/nancy_pelosi/400314",
-        middlename: "",
-        name: "Rep. Nancy Pelosi [D-CA12]",
-        namemod: "",
-        nickname: "",
-        osid: "N00007360",
-        pvsid: "26732",
-        sortname: "Pelosi, Nancy (Rep.) [D-CA12]",
-        twitterid: "NancyPelosi",
-        youtubeid: "nancypelosi"
+        firstname: 'Nancy',
+        lastname: 'Pelosi'
       },
-      phone: "202-225-4965",
-      role_type: "representative",
-      role_type_label: "Representative",
-      senator_class: null,
-      senator_rank: null,
-      startdate: "2015-01-06",
-      state: "CA",
-      title: "Rep.",
-      title_long: "Representative",
-      website: "http://pelosi.house.gov"
+      title: 'Rep.',
+      party: 'Democrat',
+      phone: '(202) 225-4965'
     }
   ],
   senators: [
     {
-      caucus: null,
-      congress_numbers: [
-        112,
-        113,
-        114
-      ],
-      current: true,
-      description: "Junior Senator from California",
-      district: null,
-      enddate: "2017-01-03",
-      extra: {
-        address: "112 Hart Senate Office Building Washington DC 20510",
-        contact_form: "https://www.boxer.senate.gov/contact/shareyourviews.html",
-        fax: "202-224-0454",
-        office: "112 Hart Senate Office Building"
-      },
-      id: 3853,
-      leadership_title: null,
-      party: "Democrat",
       person: {
-        bioguideid: "B000711",
-        birthday: "1940-11-11",
-        cspanid: 2470,
-        firstname: "Barbara",
-        gender: "female",
-        gender_label: "Female",
-        id: 300011,
-        lastname: "Boxer",
-        link: "https://www.govtrack.us/congress/members/barbara_boxer/300011",
-        middlename: "",
-        name: "Sen. Barbara Boxer [D-CA]",
-        namemod: "",
-        nickname: "",
-        osid: "N00006692",
-        pvsid: "53274",
-        sortname: "Boxer, Barbara (Sen.) [D-CA]",
-        twitterid: "SenatorBoxer",
-        youtubeid: "SenatorBoxer"
+        firstname: 'Dianne',
+        lastname: 'Feinstein'
       },
-      phone: "202-224-3553",
-      role_type: "senator",
-      role_type_label: "Senator",
-      senator_class: "class3",
-      senator_class_label: "Class 3",
-      senator_rank: "junior",
-      senator_rank_label: "Junior",
-      startdate: "2011-01-05",
-      state: "CA",
-      title: "Sen.",
-      title_long: "Senator",
-      website: "https://www.boxer.senate.gov"
-    },
-    {
-      caucus: null,
-      congress_numbers: [
-        113,
-        114,
-        115
-      ],
-      current: true,
-      description: "Senior Senator from California",
-      district: null,
-      enddate: "2019-01-03",
-      extra: {
-        address: "331 Hart Senate Office Building Washington DC 20510",
-        contact_form: "https://www.feinstein.senate.gov/public/index.cfm/e-mail-me",
-        fax: "202-228-3954",
-        office: "331 Hart Senate Office Building",
-        rss_url: "http://www.feinstein.senate.gov/public/?a=rss.feed"
-      },
-      id: 42868,
-      leadership_title: null,
-      party: "Democrat",
+      title: 'Sen.',
+      party: 'Democrat',
+      phone: '(202) 224-3841'
+    }, {
       person: {
-        bioguideid: "F000062",
-        birthday: "1933-06-22",
-        cspanid: 13061,
-        firstname: "Dianne",
-        gender: "female",
-        gender_label: "Female",
-        id: 300043,
-        lastname: "Feinstein",
-        link: "https://www.govtrack.us/congress/members/dianne_feinstein/300043",
-        middlename: "",
-        name: "Sen. Dianne Feinstein [D-CA]",
-        namemod: "",
-        nickname: "",
-        osid: "N00007364",
-        pvsid: "53273",
-        sortname: "Feinstein, Dianne (Sen.) [D-CA]",
-        twitterid: "SenFeinstein",
-        youtubeid: "SenatorFeinstein"
+        firstname: 'Kamala D.',
+        lastname: 'Harris'
       },
-      phone: "202-224-3841",
-      role_type: "senator",
-      role_type_label: "Senator",
-      senator_class: "class1",
-      senator_class_label: "Class 1",
-      senator_rank: "senior",
-      senator_rank_label: "Senior",
-      startdate: "2013-01-03",
-      state: "CA",
-      title: "Sen.",
-      title_long: "Senator",
-      website: "http://www.feinstein.senate.gov"
+      title: 'Sen.',
+      party: 'Democrat',
+      phone: '(202) 224-3553'
     }
   ]
 };
@@ -359,54 +97,13 @@ export const NO_SENATORS = {
   },
   representatives: [
     {
-      caucus: null,
-      congress_numbers: [
-        114
-      ],
-      current: true,
-      description: "Representative for California's 12th congressional district",
-      district: 12,
-      enddate: "2017-01-03",
-      extra: {
-        address: "233 Cannon HOB; Washington DC 20515-0512",
-        contact_form: "http://pelosi.house.gov/contact-me/email-me",
-        fax: "202-225-8259",
-        office: "233 Cannon House Office Building",
-        rss_url: "http://pelosi.house.gov/atom.xml"
-      },
-      id: 43364,
-      leadership_title: "Minority Leader",
-      party: "Democrat",
       person: {
-        bioguideid: "P000197",
-        birthday: "1940-03-26",
-        cspanid: 6153,
-        firstname: "Nancy",
-        gender: "female",
-        gender_label: "Female",
-        id: 400314,
-        lastname: "Pelosi",
-        link: "https://www.govtrack.us/congress/members/nancy_pelosi/400314",
-        middlename: "",
-        name: "Rep. Nancy Pelosi [D-CA12]",
-        namemod: "",
-        nickname: "",
-        osid: "N00007360",
-        pvsid: "26732",
-        sortname: "Pelosi, Nancy (Rep.) [D-CA12]",
-        twitterid: "NancyPelosi",
-        youtubeid: "nancypelosi"
+        firstname: 'Nancy',
+        lastname: 'Pelosi'
       },
-      phone: "202-225-4965",
-      role_type: "representative",
-      role_type_label: "Representative",
-      senator_class: null,
-      senator_rank: null,
-      startdate: "2015-01-06",
-      state: "CA",
-      title: "Rep.",
-      title_long: "Representative",
-      website: "http://pelosi.house.gov"
+      title: 'Rep.',
+      party: 'Democrat',
+      phone: '(202) 225-4965'
     }
   ]
 };

--- a/tests/fixtures/congressperson.js
+++ b/tests/fixtures/congressperson.js
@@ -1,107 +1,23 @@
 export const COMPLETE_PROFILE = {
-  caucus: null,
-  congress_numbers: [
-    114
-  ],
-  current: true,
-  description: "Representative for California's 12th congressional district",
-  district: 12,
-  enddate: "2017-01-03",
-  extra: {
-    address: "233 Cannon HOB; Washington DC 20515-0512",
-    contact_form: "http://pelosi.house.gov/contact-me/email-me",
-    fax: "202-225-8259",
-    office: "233 Cannon House Office Building",
-    rss_url: "http://pelosi.house.gov/atom.xml"
-  },
-  id: 43364,
-  leadership_title: "Minority Leader",
-  party: "Democrat",
   person: {
-    bioguideid: "P000197",
-    birthday: "1940-03-26",
-    cspanid: 6153,
-    firstname: "Nancy",
-    gender: "female",
-    gender_label: "Female",
-    id: 400314,
-    lastname: "Pelosi",
-    link: "https://www.govtrack.us/congress/members/nancy_pelosi/400314",
-    middlename: "",
-    name: "Rep. Nancy Pelosi [D-CA12]",
-    namemod: "",
-    nickname: "",
-    osid: "N00007360",
-    pvsid: "26732",
-    sortname: "Pelosi, Nancy (Rep.) [D-CA12]",
-    twitterid: "NancyPelosi",
-    youtubeid: "nancypelosi"
+    firstname: 'Nancy',
+    lastname: 'Pelosi'
   },
-  phone: "202-225-4965",
-  role_type: "representative",
-  role_type_label: "Representative",
-  senator_class: null,
-  senator_rank: null,
-  startdate: "2015-01-06",
-  state: "CA",
-  title: "Rep.",
-  title_long: "Representative",
-  website: "http://pelosi.house.gov"
+  title: 'Rep.',
+  party: 'Democrat',
+  phone: '(202) 225-4965'
 };
 
 export const ONLY_NAME = {
   person: {
-    firstname: "Nancy",
-    lastname: "Pelosi"
+    firstname: 'Nancy',
+    lastname: 'Pelosi'
   },
-  title: "Rep."
+  title: 'Rep.'
 };
 
-export const NO_CONTACT_INFORMATION = {
-  caucus: null,
-  congress_numbers: [
-    114
-  ],
-  current: true,
-  description: "Representative for California's 12th congressional district",
-  district: 12,
-  enddate: "2017-01-03",
-  extra: {
-    address: "233 Cannon HOB; Washington DC 20515-0512",
-    contact_form: "http://pelosi.house.gov/contact-me/email-me",
-    fax: "202-225-8259",
-    office: "233 Cannon House Office Building",
-    rss_url: "http://pelosi.house.gov/atom.xml"
-  },
-  id: 43364,
-  leadership_title: "Minority Leader",
-  party: "Democrat",
-  person: {
-    bioguideid: "P000197",
-    birthday: "1940-03-26",
-    cspanid: 6153,
-    firstname: "Nancy",
-    gender: "female",
-    gender_label: "Female",
-    id: 400314,
-    lastname: "Pelosi",
-    link: "https://www.govtrack.us/congress/members/nancy_pelosi/400314",
-    middlename: "",
-    name: "Rep. Nancy Pelosi [D-CA12]",
-    namemod: "",
-    nickname: "",
-    osid: "N00007360",
-    pvsid: "26732",
-    sortname: "Pelosi, Nancy (Rep.) [D-CA12]",
-    youtubeid: "nancypelosi"
-  },
-  role_type: "representative",
-  role_type_label: "Representative",
-  senator_class: null,
-  senator_rank: null,
-  startdate: "2015-01-06",
-  state: "CA",
-  title: "Rep.",
-  title_long: "Representative",
-  website: "http://pelosi.house.gov"
+export const VACANT_SEAT = {
+  vacant: true,
+  footnote: 'Vacancy due to the resignation of Ryan K. Zinke, March 1, 2017.',
+  phone: '(202) 225-3211'
 };

--- a/tests/integration/components/display-congressperson-test.js
+++ b/tests/integration/components/display-congressperson-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import {
   COMPLETE_PROFILE,
   NAME_ONLY,
-  NO_CONTACT_INFORMATION
+  VACANT_SEAT
 } from '../../fixtures/congressperson';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -15,10 +15,8 @@ test('it renders', function(assert) {
   this.render(hbs`{{display-congressperson congressperson=congressperson}}`);
 
   assert.ok(this.$('.display-congressperson__name').text().match('Rep. Nancy Pelosi'), 'displays correctly formatted full name');
-  assert.ok(this.$('.display-congressperson__phone').text().match('202-225-4965'), 'displays phone number');
-  assert.ok(this.$('.display-congressperson__twitter').text().match('@NancyPelosi'), 'displays correctly formatted Twitter handle');
+  assert.ok(this.$('.display-congressperson__phone').text().match(/\(202\) 225-4965/), 'displays phone number');
   assert.ok(this.$('.display-congressperson__party').text().match('Democrat'), 'displays party affiliation');
-  assert.equal(this.$('.display-congressperson__voting-record__link').attr('href'), 'https://www.govtrack.us/congress/members/nancy_pelosi/400314', 'links to voting record');
 });
 
 test('it handles incomplete data', function(assert) {
@@ -27,16 +25,14 @@ test('it handles incomplete data', function(assert) {
 
   assert.equal(this.$('.display-congressperson__name').length, 1, 'name always exists');
   assert.equal(this.$('.display-congressperson__phone').length, 0, 'does not render attributes that do not exist');
-  assert.equal(this.$('.display-congressperson__twitter').length, 0, 'does not render attributes that do not exist');
   assert.equal(this.$('.display-congressperson__party').length, 0, 'does not render attributes that do not exist');
-  assert.equal(this.$('.display-congressperson__voting-record').length, 0, 'does not render attributes that do not exist');
+});
 
-  this.set('congressperson', NO_CONTACT_INFORMATION);
+test('it handles vacant seat', function(assert) {
+  this.set('congressperson', VACANT_SEAT);
   this.render(hbs`{{display-congressperson congressperson=congressperson}}`);
 
-  assert.equal(this.$('.display-congressperson__name').length, 1, 'name always exists');
-  assert.equal(this.$('.display-congressperson__phone').length, 0, 'does not render attributes that do not exist');
-  assert.equal(this.$('.display-congressperson__twitter').length, 0, 'does not render attributes that do not exist');
-  assert.equal(this.$('.display-congressperson__party').length, 1, 'renders attributes that do exist');
-  assert.equal(this.$('.display-congressperson__voting-record').length, 1, 'renders attributes that do exist');
+  assert.ok(this.$('.display-congressperson__name').text().match('Vacant Seat'), 'displays vacant seat title');
+  assert.ok(this.$('.display-congressperson__name').text().match('Vacancy due to the resignation of Ryan K. Zinke, March 1, 2017'), 'displays vacant seat footnote');
+  assert.equal(this.$('.display-congressperson__phone').length, 0, 'does not render attributes even if they exist');
 });


### PR DESCRIPTION
Instead of using GovTrack's API to look up data on each member of Congress, use the free APIs provided by the [US House of Representatives](https://xml.house.gov/) and the [US Senate](https://www.senate.gov/general/XML.htm). This should prevent problems when the [GovTrack APIs](https://www.govtrack.us/developers/api) are shut off in Summer 2017.

Also adds support for displaying vacant seats in the House. I can't find any examples or documentation of how vacant seats in the Senate are formatted, so will have to do that one later.