### PR TITLE
Re-introduce WhoIsMyRepresentative.com for zip-only searches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ You will need the following things properly installed on your computer.
 
 Since this application includes both a front end and a back end, you will need to start up two servers to begin development.
 
-* `npm run backend`
+*Note: Running the backend requires access to ProPublica. You'll need access to an API key to make valid requests.*
+
+* `PROPUBLICA_API_KEY=[...] npm run backend`
 * `npm run frontend`
 * Visit [http://localhost:4200](http://localhost:4200) to see the app running locally.
 

--- a/app/components/lookup-congress.js
+++ b/app/components/lookup-congress.js
@@ -52,11 +52,6 @@ export default Ember.Component.extend({
       return;
     }
 
-    if (Ember.isNone(this.get('lookupData.street'))) {
-      this.get('message').display('errors.server.MISSING_STREET');
-      return;
-    }
-
     this.lookupDistrict();
   }
 });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -40,7 +40,7 @@ export default {
   },
 
   about: {
-    attribution: "This app runs off data made freely available by the {{link-census}}US Census Geocoding Services{{/link-census}} and {{link-propublica}}ProPublica{{/link-propublica}}. It was created by {{link-marie}}Marie Chatfield{{/link-marie}}. View the source code or contribute changes on {{link-github}}GitHub{{/link-github}}."
+    attribution: "This app runs off data made freely available by the {{link-census}}US Census Geocoding Services{{/link-census}}, {{link-propublica}}ProPublica{{/link-propublica}}, and {{link-whois}}WhoIsMyRepresentative.com{{/link-whois}}. It was created by {{link-marie}}Marie Chatfield{{/link-marie}}. View the source code or contribute changes on {{link-github}}GitHub{{/link-github}}."
   },
 
   errors: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -22,7 +22,7 @@ export default {
  },
 
   geography: {
-    address: 'Street Address',
+    address: 'Street Address (optional)',
     district: 'Congressional District',
     state: 'State',
     zipCode: 'Zip Code'
@@ -51,7 +51,6 @@ export default {
       INVALID_DISTRICT_ID: 'Provided URL does not map to a valid state and district number.',
       INVALID_STATE: 'State abbreviation provided does not match any known states.',
       MISSING_ZIP: 'Please provide a valid zip code.',
-      MISSING_STREET: 'Please provide a street address. CallMyCongress.com no longer supports zip-only searches, as the source of our data for zip code to congressional districts was shut down. We apologize for the inconvenience.',
       MISSING_DISTRICT_ID: 'Please provide a valid district id to look up representatives.',
       UNKNOWN: 'Something went wrong.'
     }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,5 +14,6 @@
                         links=(hash census="https://geocoding.geo.census.gov/"
                                     propublica="https://www.propublica.org/datastore/apis"
                                     marie="http://mariechatfield.com/"
-                                    github="https://github.com/mchat/call-my-congress")}}
+                                    github="https://github.com/mchat/call-my-congress"
+                                    whois="http://whoismyrepresentative.com/api")}}
 </div>

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -86,9 +86,8 @@ describe('server', function() {
           .expect(500, { translationKey: 'UNKNOWN' }, done);
       });
 
-      /* TODO: If we can find a new source of data for zip-to-congressional-district, re-enable these tests. */
-      describe.skip('providing only zip code', function() {
-        const apiURL = ''; // TODO: replace with new API url if one can be found
+      describe('providing only zip code', function() {
+        const apiURL = 'http://whoismyrepresentative.com/getall_mems.php?output=json&zip=20500';
         const serverURL = '/api/district-from-address?zip=20500';
 
         it('with successful API calls, returns correctly formatted response', function testSlash(done) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.9.0",
     "ember-export-application-global": "^1.0.5",
     "ember-i18n": "4.3.2",
     "ember-load-initializers": "^0.5.1",


### PR DESCRIPTION
A few months ago, I removed the dependency on WhoIsMyRepresentative.com as the site was down. I mistakenly thought the site was no longer being maintained. That appears to not be the case.

I'm reverting my changes from #27, which means people can once again search for their representatives using just their zip code (and not full street address).

Resolves #1.