### PR TITLE
Handle non-voting districts correctly.

### DIFF
--- a/backend/tests/fixtures/api.js
+++ b/backend/tests/fixtures/api.js
@@ -467,6 +467,34 @@ const AT_LARGE_CONGRESS_RESPONSE = {
   ]
 };
 
+const NON_VOTING_AT_LARGE_CONGRESS_RESPONSE = {
+  district: {
+    districts: [
+      {
+        state: 'PR',
+        number: '0',
+        id: 'PR-0'
+      }
+    ]
+  },
+  representatives: [
+    {
+      title: 'Rep.',
+      person: {
+        firstname: 'Jenniffer',
+        lastname: 'González-Colón'
+      },
+      party: 'Republican',
+      phone: '',
+      twitter: 'repjenniffer',
+      govtrack: '412723',
+      cspan: '67353',
+      next_election: '2018'
+    }
+  ],
+  senators: []
+};
+
 module.exports = {
   DISTRICT,
   AT_LARGE_DISTRICT,
@@ -479,5 +507,6 @@ module.exports = {
   AT_LARGE_DISTRICT_RESPONSE,
   NON_VOTING_DISTRICT_RESPONSE,
   CONGRESS_RESPONSE,
-  AT_LARGE_CONGRESS_RESPONSE
+  AT_LARGE_CONGRESS_RESPONSE,
+  NON_VOTING_AT_LARGE_CONGRESS_RESPONSE
 };

--- a/backend/tests/server-test.js
+++ b/backend/tests/server-test.js
@@ -180,6 +180,15 @@ describe('server', function() {
           .expect(200, fixtures.AT_LARGE_CONGRESS_RESPONSE, done);
       });
 
+      it('with a non-voting state with an at-large district, returns correctly formatted response', function testSlash(done) {
+        stubRequest(validRepresentativeURL, houseFixtures.REPRESENTATIVES);
+        stubRequest(validSenatorURL, senateFixtures.SENATORS);
+
+        supertest(this.server)
+          .get('/api/congress-from-district?id=PR-0')
+          .expect(200, fixtures.NON_VOTING_AT_LARGE_CONGRESS_RESPONSE, done);
+      });
+
       it('with failed API calls, returns correctly formatted error response', function testSlash(done) {
         stubRequest(validRepresentativeURL, { message: 'failed with some error' }, true);
         stubRequest(validSenatorURL, { message: 'another error' }, true);


### PR DESCRIPTION
ProPublica's API treats voting and non-voting at-large districts differently. Non-voting districts have an `undefined` district number, while voting districts have a district number of `1`. I was correctly handling the voting case (e.g. Alaska) but not the non-voting case (e.g. Puerto Rico, Guam, US Virgin Islands, etc). I've updated the code that looks for representatives. It only attempts to match the district number if the district is not at-large. This means that the app now correctly handles and returns responses for non-voting at-large districts again.