### PR TITLE
Remove dependency on bower.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 
 # dependencies
 /node_modules
-/bower_components
 
 # misc
 /.sass-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,11 @@ cache:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
-  - bower --version
   - npm install phantomjs-prebuilt
   - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
   - npm install
-  - bower install
 
 script:
   - npm test

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ You will need the following things properly installed on your computer.
 
 * [Git](http://git-scm.com/)
 * [Node.js](http://nodejs.org/) (with NPM)
-* [Bower](http://bower.io/)
 * [Ember CLI](http://ember-cli.com/)
 * [PhantomJS](http://phantomjs.org/)
 
@@ -25,7 +24,6 @@ You will need the following things properly installed on your computer.
 * `git clone https://github.com/mchat/call-my-congress.git` this repository
 * `cd call-my-congress`
 * `npm install`
-* `bower install`
 
 ## Running / Development
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "call-my-congress",
-  "dependencies": {
-    "ember": "~2.15.0"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "supertest": "^3.0.0"
   },
   "dependencies": {
+    "ember-source": "^2.15.0",
     "express": "^4.14.0",
     "request": "^2.79.0"
   }


### PR DESCRIPTION
As of Ember CLI 2.11, bower is no longer a requirement. Install ember source via npm instead of bower, and remove any bower references or dependencies in the application to reduce bloat.